### PR TITLE
Fix vertical alignment of the text logo

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -15,7 +15,7 @@ const LeftSide: React.FC = () => {
   const isRootPage = pathname === '/';
 
   return (
-    <div className="bg-black p-5 pr-5 md:pr-10 md:pl-10 xl:w-max align-middle items-center flex-shrink">
+    <div className="bg-black p-5 pr-5 md:pr-10 md:pl-10 xl:w-max align-middle flex items-center flex-shrink">
       {/* root */}
       <Link href="/">
         <a className={classNames('block', { hidden: !isRootPage })}>
@@ -31,7 +31,7 @@ const LeftSide: React.FC = () => {
       </Link>
       {/* others */}
       <Link href="/">
-        <a className={classNames('block', { hidden: isRootPage })}>
+        <a className={classNames('flex items-center', { hidden: isRootPage })}>
           <CustomImage
             src={logoOneLine}
             alt="Vegan Hacktivists Logo"


### PR DESCRIPTION
This is how the text version of VH's logo currently looks:
![Screenshot from 2022-03-06 22-28-30](https://user-images.githubusercontent.com/16514302/156963599-51299a22-c196-41d5-93be-d52a76de6438.png)

And what I've done:
![Screenshot from 2022-03-06 22-29-58](https://user-images.githubusercontent.com/16514302/156963597-4282a930-5ec0-43f0-935f-84dce62c8f18.png)


