### PR TITLE
Adding newsletter-popup prevention for /docs/* and error pages

### DIFF
--- a/src/components/layout/errorPage.tsx
+++ b/src/components/layout/errorPage.tsx
@@ -19,8 +19,8 @@ import { StatusCodes } from 'http-status-codes';
 import type { FallbackProps } from 'react-error-boundary';
 import { useEffect } from 'react';
 
-export interface ErrorProps extends FallbackProps {
-  error: FallbackProps['error'] & {
+export interface ErrorProps extends Omit<FallbackProps, 'error'> {
+  error?: FallbackProps['error'] & {
     statusCode?: number;
   };
 }
@@ -44,7 +44,7 @@ const Error: NextPage<ErrorProps> = ({ error, resetErrorBoundary }) => {
   const contactPageError: string | boolean = router.asPath === '/contact';
 
   const message =
-    error.statusCode === StatusCodes.NOT_FOUND ? 'Page not found.' : 'Whoops!';
+    error?.statusCode === StatusCodes.NOT_FOUND ? 'Page not found.' : 'Whoops!';
 
   return (
     <>

--- a/src/components/layout/errorPage.tsx
+++ b/src/components/layout/errorPage.tsx
@@ -19,15 +19,13 @@ import { StatusCodes } from 'http-status-codes';
 import type { FallbackProps } from 'react-error-boundary';
 import { useEffect } from 'react';
 
-interface ErrorProps extends Partial<FallbackProps> {
-  statusCode?: number;
+export interface ErrorProps extends FallbackProps {
+  error: FallbackProps['error'] & {
+    statusCode?: number;
+  };
 }
 
-const Error: NextPage<ErrorProps> = ({
-  statusCode,
-  error,
-  resetErrorBoundary,
-}) => {
+const Error: NextPage<ErrorProps> = ({ error, resetErrorBoundary }) => {
   const router = useRouter();
 
   useEffect(() => {
@@ -40,33 +38,33 @@ const Error: NextPage<ErrorProps> = ({
 
   const handleContactClick = () => {
     resetErrorBoundary?.();
-    setErrorData({ pageThatErrored: router.asPath, statusCode, error });
+    setErrorData({ pageThatErrored: router.asPath, error });
   };
 
   const contactPageError: string | boolean = router.asPath === '/contact';
 
   const message =
-    statusCode === StatusCodes.NOT_FOUND ? 'Page not found.' : 'Whoops!';
+    error.statusCode === StatusCodes.NOT_FOUND ? 'Page not found.' : 'Whoops!';
 
   return (
     <>
       <NextSeo noindex title="Page Not Found" />
       <article className="min-h-[40rem] flex flex-col justify-center items-center p-4">
         <div className="flex flex-col gap-4">
-          <div className="flex flex-col md:flex-row justify-start gap-12">
+          <div className="flex flex-col justify-start gap-12 md:flex-row">
             <div className="w-80">
               <CustomImage src={errorTypeImage} alt="ERROR" priority />
             </div>
-            <div className="flex flex-col items-start justify-evenly gap-3 md:gap-0 text-2xl text-center md:text-left">
-              <h1 className="text-red font-mono font-bold w-full">{message}</h1>
-              <div className="font-mono w-full">
+            <div className="flex flex-col items-start gap-3 text-2xl text-center justify-evenly md:gap-0 md:text-left">
+              <h1 className="w-full font-mono font-bold text-red">{message}</h1>
+              <div className="w-full font-mono">
                 {contactPageError
                   ? 'Please contact us at...'
                   : 'If you believe this is a mistake...'}
               </div>
             </div>
           </div>
-          <div className="flex flex-col-reverse md:flex-row justify-start gap-12">
+          <div className="flex flex-col-reverse justify-start gap-12 md:flex-row">
             <div className="md:-mt-3">
               {[avocado, mango, peach, sweetPotato, watermelon].map((fruit) => (
                 <CustomImage
@@ -78,9 +76,9 @@ const Error: NextPage<ErrorProps> = ({
                 />
               ))}
             </div>
-            <div className="w-full md:w-min flex justify-center">
+            <div className="flex justify-center w-full md:w-min">
               {contactPageError ? (
-                <span className="font-mono text-2xl md:text-left font-bold">
+                <span className="font-mono text-2xl font-bold md:text-left">
                   <Link
                     href={{
                       pathname: 'mailto:hello@veganhacktivists.org',
@@ -88,7 +86,7 @@ const Error: NextPage<ErrorProps> = ({
                         subject: 'Website error!',
                         body: generateErrorMessage({
                           pageThatErrored: router.asPath,
-                          statusCode,
+                          error,
                         }),
                       },
                     }}

--- a/src/components/layout/newsletterPopup.tsx
+++ b/src/components/layout/newsletterPopup.tsx
@@ -4,7 +4,7 @@ import Newsletter from './newsletter';
 import { useCookies } from 'react-cookie';
 
 const NewsletterPopup: React.FC = () => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
   const [cookies, setCookies] = useCookies(['newsletter']);
   const userHasSignedUp = cookies['newsletter'] !== undefined;
 

--- a/src/components/layout/wrapper.tsx
+++ b/src/components/layout/wrapper.tsx
@@ -22,7 +22,7 @@ const JumpToContent: React.FC = () => {
   );
 };
 
-const PageWrapper: React.FC<React.PropsWithChildren> = ({ children }) => {
+const PageWrapper: React.FC = ({ children }) => {
   return (
     <>
       <JumpToContent />

--- a/src/components/layout/wrapper.tsx
+++ b/src/components/layout/wrapper.tsx
@@ -6,6 +6,8 @@ import CookiesCTA from '../cookiesCTA';
 import NewsletterPopup from './newsletterPopup';
 
 import 'react-toastify/dist/ReactToastify.css';
+import NotFound from '../../pages/404';
+import _error from '../../pages/_error';
 
 // http://web-accessibility.carnegiemuseums.org/code/skip-link/
 const JumpToContent: React.FC = () => {
@@ -20,7 +22,7 @@ const JumpToContent: React.FC = () => {
   );
 };
 
-const PageWrapper: React.FC = ({ children }) => {
+const PageWrapper: React.FC<React.PropsWithChildren> = ({ children }) => {
   return (
     <>
       <JumpToContent />
@@ -31,9 +33,35 @@ const PageWrapper: React.FC = ({ children }) => {
   );
 };
 
-export const MainWrapper: React.FC = ({ children }) => {
+interface MainWrapperProps {
+  pathname: string;
+}
+
+export const MainWrapper: React.FC<
+  React.PropsWithChildren<MainWrapperProps>
+> = ({ children, pathname }) => {
+  const errorCallback = () => {
+    showNewsletter = false;
+  };
+
+  /*
+   * Checking for sites, where the newsletter popup shouldn't be shown
+   */
+  let showNewsletter = true;
+  if (pathname === '/docs' || pathname.startsWith('/docs/')) {
+    showNewsletter = false;
+  }
+  //I expect only one Element (the error page) getting passed as children
+  if (children && typeof children === 'object' && 'type' in children) {
+    //Check for the error pages
+    if (children.type === NotFound || children.type === _error) {
+      showNewsletter = false;
+    }
+  }
+
   return (
     <ErrorBoundary
+      onError={errorCallback}
       fallbackRender={(props) => {
         return <ErrorPage {...props} />;
       }}
@@ -41,7 +69,7 @@ export const MainWrapper: React.FC = ({ children }) => {
       <main id="main" className="text-center min-h-[40rem]" tabIndex={-1}>
         {children}
         <CookiesCTA />
-        <NewsletterPopup />
+        {showNewsletter && <NewsletterPopup />}
       </main>
       <ToastContainer position="bottom-right" />
     </ErrorBoundary>

--- a/src/components/layout/wrapper.tsx
+++ b/src/components/layout/wrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { ToastContainer } from 'react-toastify';
 import ErrorPage from '../../pages/_error';
@@ -6,15 +6,13 @@ import CookiesCTA from '../cookiesCTA';
 import NewsletterPopup from './newsletterPopup';
 
 import 'react-toastify/dist/ReactToastify.css';
-import NotFound from '../../pages/404';
-import _error from '../../pages/_error';
 
 // http://web-accessibility.carnegiemuseums.org/code/skip-link/
 const JumpToContent: React.FC = () => {
   return (
     <a
       role="button"
-      className="text-white absolute top-0 text-center left-1/2 -translate-x-1/2 sm:left-2/3 xl:left-1/3 px-3 py-2 -translate-y-full focus:translate-y-22 md:focus:translate-y-2 z-30 transition-transform rounded-md"
+      className="absolute top-0 z-30 px-3 py-2 text-center text-white transition-transform -translate-x-1/2 -translate-y-full rounded-md left-1/2 sm:left-2/3 xl:left-1/3 focus:translate-y-22 md:focus:translate-y-2"
       href="#main"
     >
       Jump to content
@@ -26,7 +24,7 @@ const PageWrapper: React.FC = ({ children }) => {
   return (
     <>
       <JumpToContent />
-      <div className="flex flex-col justify-between min-h-screen w-full">
+      <div className="flex flex-col justify-between w-full min-h-screen">
         {children}
       </div>
     </>
@@ -40,28 +38,18 @@ interface MainWrapperProps {
 export const MainWrapper: React.FC<
   React.PropsWithChildren<MainWrapperProps>
 > = ({ children, pathname }) => {
-  const errorCallback = () => {
-    showNewsletter = false;
-  };
+  // TODO: probably better to check the store, showing the popup on the bug submit form is ugly
+  const [hasError, setHasError] = useState(false);
 
-  /*
-   * Checking for sites, where the newsletter popup shouldn't be shown
-   */
-  let showNewsletter = true;
-  if (pathname === '/docs' || pathname.startsWith('/docs/')) {
-    showNewsletter = false;
-  }
-  //I expect only one Element (the error page) getting passed as children
-  if (children && typeof children === 'object' && 'type' in children) {
-    //Check for the error pages
-    if (children.type === NotFound || children.type === _error) {
-      showNewsletter = false;
-    }
-  }
+  const showNewsletter =
+    !hasError || pathname === '/docs' || pathname.startsWith('/docs/');
 
   return (
     <ErrorBoundary
-      onError={errorCallback}
+      onError={() => {
+        setHasError(true);
+      }}
+      onReset={() => setHasError(false)}
       fallbackRender={(props) => {
         return <ErrorPage {...props} />;
       }}

--- a/src/components/layout/wrapper.tsx
+++ b/src/components/layout/wrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { ToastContainer } from 'react-toastify';
 import ErrorPage from '../../pages/_error';
@@ -6,6 +6,8 @@ import CookiesCTA from '../cookiesCTA';
 import NewsletterPopup from './newsletterPopup';
 
 import 'react-toastify/dist/ReactToastify.css';
+import useErrorStore from '../../lib/stores/errorStore';
+import { useRouter } from 'next/router';
 
 // http://web-accessibility.carnegiemuseums.org/code/skip-link/
 const JumpToContent: React.FC = () => {
@@ -31,25 +33,15 @@ const PageWrapper: React.FC = ({ children }) => {
   );
 };
 
-interface MainWrapperProps {
-  pathname: string;
-}
+export const MainWrapper: React.FC = ({ children }) => {
+  const error = useErrorStore((state) => state.error);
+  const { asPath } = useRouter();
 
-export const MainWrapper: React.FC<
-  React.PropsWithChildren<MainWrapperProps>
-> = ({ children, pathname }) => {
-  // TODO: probably better to check the store, showing the popup on the bug submit form is ugly
-  const [hasError, setHasError] = useState(false);
-
-  const showNewsletter =
-    !hasError || pathname === '/docs' || pathname.startsWith('/docs/');
+  const hideNewsletter =
+    error || asPath === '/docs' || asPath.startsWith('/docs/');
 
   return (
     <ErrorBoundary
-      onError={() => {
-        setHasError(true);
-      }}
-      onReset={() => setHasError(false)}
       fallbackRender={(props) => {
         return <ErrorPage {...props} />;
       }}
@@ -57,7 +49,7 @@ export const MainWrapper: React.FC<
       <main id="main" className="text-center min-h-[40rem]" tabIndex={-1}>
         {children}
         <CookiesCTA />
-        {showNewsletter && <NewsletterPopup />}
+        {hideNewsletter || <NewsletterPopup />}
       </main>
       <ToastContainer position="bottom-right" />
     </ErrorBoundary>

--- a/src/lib/stores/errorStore.ts
+++ b/src/lib/stores/errorStore.ts
@@ -2,8 +2,7 @@ import create from 'zustand';
 
 export interface ErrorStoreProps {
   pageThatErrored?: string;
-  statusCode?: number;
-  error?: Error;
+  error?: Error & { statusCode?: number };
 }
 
 interface ErrorStoreMethods {
@@ -15,33 +14,30 @@ interface ErrorStoreMethods {
 const useErrorStore = create<ErrorStoreProps & ErrorStoreMethods>(
   (set, get) => ({
     pageThatErrored: undefined,
-    statusCode: undefined,
 
-    setErrorData: ({ pageThatErrored, statusCode, error }) =>
+    setErrorData: ({ pageThatErrored, error }) =>
       set(() => ({
         pageThatErrored,
-        statusCode,
         error,
       })),
 
     clearErrorData: () =>
       set(() => ({
         pageThatErrored: undefined,
-        statusCode: undefined,
         error: undefined,
       })),
     generateErrorMessage: (context) => {
-      const { pageThatErrored, statusCode, error } = context || get();
+      const { pageThatErrored, error } = context || get();
 
-      const thenHappened = error
-        ? 'a client error happened'
-        : `I found a ${statusCode} error`;
+      const thenHappened = error?.statusCode
+        ? `I found a ${error?.statusCode} error`
+        : 'a client error happened';
 
       const defaultErrorMessage = pageThatErrored
         ? `[Please tell us what you were doing prior to the error occurring...]
 
 ...then ${thenHappened} at ${pageThatErrored}${
-            error ? `: ${error.name}. ${error.message}` : ''
+            error?.name ? `: ${error.name}. ${error.message}` : ''
           }.
 
 Thanks!`

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,8 +1,35 @@
-import { StatusCodes } from 'http-status-codes';
-import ErrorPage from '../components/layout/errorPage';
+import { ReasonPhrases, StatusCodes } from 'http-status-codes';
+import { useRouter } from 'next/router';
+import { useEffect, useMemo } from 'react';
+import { useErrorHandler } from 'react-error-boundary';
+import type { ErrorProps } from '../components/layout/errorPage';
+import useErrorStore from '../lib/stores/errorStore';
+import ErrorPage from './_error';
 
 const NotFound: React.FC = () => {
-  return <ErrorPage statusCode={StatusCodes.NOT_FOUND} />;
+  const handleError = useErrorHandler();
+
+  // If we don't check if an error was already thrown it will be thrown again
+  const error = useErrorStore((state) => state.error);
+  const { asPath } = useRouter();
+
+  const notFoundErrorProps: ErrorProps['error'] = useMemo(
+    () => ({
+      statusCode: StatusCodes.NOT_FOUND,
+      name: ReasonPhrases.NOT_FOUND,
+      message: `The page you requested (${asPath}) does not exist`,
+    }),
+    [asPath]
+  );
+
+  useEffect(() => {
+    if (error) return;
+    handleError(notFoundErrorProps);
+  }, []);
+
+  // I'd love to avoid rendering this, but otherwise the page will be blank if the user goes back
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  return <ErrorPage resetErrorBoundary={() => {}} error={notFoundErrorProps} />;
 };
 
 export default NotFound;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -50,7 +50,7 @@ const getDefaultLayout: (
     return (
       <>
         <Header />
-        <MainWrapper pathname={pathname}>{page}</MainWrapper>
+        <MainWrapper>{page}</MainWrapper>
       </>
     );
   }
@@ -58,7 +58,7 @@ const getDefaultLayout: (
   return (
     <>
       <Header />
-      <MainWrapper pathname={pathname}>{page}</MainWrapper>
+      <MainWrapper>{page}</MainWrapper>
       <Footer />
     </>
   );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -50,7 +50,7 @@ const getDefaultLayout: (
     return (
       <>
         <Header />
-        <MainWrapper>{page}</MainWrapper>
+        <MainWrapper pathname={pathname}>{page}</MainWrapper>
       </>
     );
   }
@@ -58,7 +58,7 @@ const getDefaultLayout: (
   return (
     <>
       <Header />
-      <MainWrapper>{page}</MainWrapper>
+      <MainWrapper pathname={pathname}>{page}</MainWrapper>
       <Footer />
     </>
   );

--- a/src/pages/services.tsx
+++ b/src/pages/services.tsx
@@ -163,7 +163,7 @@ const Services: React.FC = () => (
         selective with who we can help with our limited resources. Ask us either
         way!
       </FirstSubSection>
-      <div className="flex flex-col md:space-y-20 items-center mx-auto text-2xl mb-20">
+      <div className="flex flex-col items-center mx-auto mb-20 text-2xl md:space-y-20">
         {SERVICE_BLOCKS.map((service, index) => (
           <Service
             key={service.title}
@@ -172,7 +172,7 @@ const Services: React.FC = () => (
           />
         ))}
       </div>
-      <div className="mb-20 flex flex-col mx-auto gap-y-4 text-2xl w-full xl:w-3/5 items-center justify-center">
+      <div className="flex flex-col items-center justify-center w-full mx-auto mb-20 text-2xl gap-y-4 xl:w-3/5">
         <CustomImage
           src={PixelBulb}
           alt=""
@@ -181,7 +181,7 @@ const Services: React.FC = () => (
           width={PixelBulb.width / 3}
         />
 
-        <div className="text-center text-grey-darker px-3 md:w-2/3">
+        <div className="px-3 text-center text-grey-darker md:w-2/3">
           We do on ocassion offer paid services for activists and/or
           organizations that need dedicated or priority speed support. If you
           fit that criteria, please contact us below. Our pricing is based on
@@ -199,8 +199,8 @@ const Services: React.FC = () => (
       ]}
       className="hidden md:block"
     />
-    <div className="bg-grey-background px-10 md:px-0 pt-10">
-      <div className="text-xl md:w-1/2 mx-auto text-grey-dark py-5">
+    <div className="px-10 pt-10 bg-grey-background md:px-0">
+      <div className="py-5 mx-auto text-xl md:w-1/2 text-grey-dark">
         If you&apos;d like to talk about any of these services, please use our
         contact form to get in touch! We do our best to respond to every email
         within 48 hours.


### PR DESCRIPTION
The newsletter popup is prevented by checking the pathname and the children type inside the MainWrapper.
When the pathname is /docs/* or the provided child component is an error page the NewsletterPoup Component doesn't get rendered.