### PR TITLE
Better request titles

### DIFF
--- a/prisma/migrations/20220902205254_200_chars_request_title_limit/migration.sql
+++ b/prisma/migrations/20220902205254_200_chars_request_title_limit/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `title` on the `PlaygroundRequest` table. The data in that column could be lost. The data in that column will be cast from `Text` to `VarChar(200)`.
+
+*/
+-- AlterTable
+ALTER TABLE "PlaygroundRequest" ALTER COLUMN "title" SET DATA TYPE VARCHAR(200);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,7 +140,7 @@ model PlaygroundRequest {
   organization      String?
   website           String
   calendlyUrl       String
-  title             String
+  title             String           @db.VarChar(200)
   requiredSkills    String[]         @default([])
   isFree            Boolean
   budget            Decimal?         @db.Money

--- a/src/components/layout/playground/applyForm.tsx
+++ b/src/components/layout/playground/applyForm.tsx
@@ -10,7 +10,7 @@ import { toast } from 'react-toastify';
 import { useRouter } from 'next/router';
 import { TimePerWeek } from '@prisma/client';
 
-import { CATEGORY_LABELS } from '../../../../prisma/constants';
+import { CATEGORY_COLORS, CATEGORY_LABELS } from '../../../../prisma/constants';
 
 import SignInPrompt from './siginInPrompt';
 import ConfirmationModal from './confirmationModal';
@@ -101,7 +101,12 @@ export const RequestDetails: React.FC<RequestProps> = ({ request }) => {
 
       <div className="relative flex flex-col-reverse justify-between gap-2 mb-4 font-mono text-xl text-left md:flex-row">
         <div className="prose prose-p:max-w-prose md:prose-xl max-w-none prose-p:leading-6 prose-headings:leading-none">
-          <div className="absolute w-16 -translate-x-full -left-5 aspect-square bg-yellow" />
+          <div
+            className="absolute w-16 -translate-x-full -left-5 aspect-square"
+            style={{
+              backgroundColor: CATEGORY_COLORS[request.category],
+            }}
+          />
           <Field title="Title">
             <h1 className="text-2xl font-bold" title={request.title}>
               {request.title}

--- a/src/components/layout/playground/applyForm.tsx
+++ b/src/components/layout/playground/applyForm.tsx
@@ -103,10 +103,7 @@ export const RequestDetails: React.FC<RequestProps> = ({ request }) => {
         <div className="prose prose-p:max-w-prose md:prose-xl max-w-none prose-p:leading-6 prose-headings:leading-none">
           <div className="absolute w-16 -translate-x-full -left-5 aspect-square bg-yellow" />
           <Field title="Title">
-            <h1
-              className="text-2xl font-bold line-clamp-1"
-              title={request.title}
-            >
+            <h1 className="text-2xl font-bold" title={request.title}>
               {request.title}
             </h1>
           </Field>

--- a/src/components/layout/playground/requests/requestCard.tsx
+++ b/src/components/layout/playground/requests/requestCard.tsx
@@ -99,7 +99,7 @@ const PlaygroundRequestCard: React.FC<
               style={{
                 borderColor: categoryColor,
               }}
-              className="px-2 py-0.5 border-[3px] rounded-xl capitalize"
+              className="px-2 py-0.5 border-[3px] rounded-xl capitalize my-auto"
             >
               {CATEGORY_LABELS[category]}
             </div>

--- a/src/components/layout/playground/requests/requestCard.tsx
+++ b/src/components/layout/playground/requests/requestCard.tsx
@@ -89,7 +89,7 @@ const PlaygroundRequestCard: React.FC<
       <div className="flex flex-col h-full gap-2 p-4 text-left">
         <div className="space-y-1">
           <h3
-            className="mb-2 mr-12 font-mono text-xl font-bold capitalize break-words md:text-2xl line-clamp-1"
+            className="mb-2 mr-12 font-mono text-xl font-bold capitalize break-words md:text-2xl line-clamp-6 md:line-clamp-4"
             title={title}
           >
             {title}

--- a/src/lib/services/playground/schemas.ts
+++ b/src/lib/services/playground/schemas.ts
@@ -87,7 +87,7 @@ const unsafeSubmitRequestSchema = z.object({
     })
     .transform((url) => (url.match(/^https?:\/\//) ? url : `http://${url}`)),
   calendlyUrl: z.string().trim().min(1, { message: 'This value is required' }),
-  title: z.string().trim().min(1),
+  title: z.string().trim().min(1).max(200),
   category: z.nativeEnum(PlaygroundRequestCategory),
   // Transform the string of skills separated by a comma in an array of strings
   requiredSkills: z


### PR DESCRIPTION
Closes #122 

- Set 200 chars title request limit (should we add limits to more things?)
- Show the full title in the request page
- Trim the title to 4 lines on small screens and 6 on the rest just to avoid weird extreme edge cases
- Some CSS fixes