### PR TITLE
154: Rework the team page

### DIFF
--- a/src/components/layout/people.tsx
+++ b/src/components/layout/people.tsx
@@ -32,6 +32,7 @@ const PeopleButtons: React.FC = () => {
   return (
     <div className="flex flex-wrap justify-center mt-10 mb-5">
       <NavButton href="/people/team">OUR TEAM</NavButton>
+      <NavButton href="/people/volunteers">VOLUNTEERS</NavButton>
       <NavButton href="/people/advisors">OUR ADVISORS</NavButton>
       <NavButton href="/people/partners">OUR PARTNERS</NavButton>
     </div>

--- a/src/pages/people/team.tsx
+++ b/src/pages/people/team.tsx
@@ -13,6 +13,7 @@ import { useHash } from '../../hooks/useHash';
 import shuffle from '../../lib/helpers/shuffle';
 import useViewMore from '../../hooks/useViewMore';
 import CustomImage from '../../components/decoration/customImage';
+import RichText from '../../components/decoration/richText';
 import SocialLinks from '../../components/layout/team/socialLinks';
 import { pixelHeart } from '../../images/separators';
 
@@ -51,96 +52,57 @@ const TeamMemberCard: React.FC<{ member: ITeamMember; teamColor: string }> = ({
   member,
   teamColor,
 }) => {
-  const { name, team, position, image, isTeamLeader, socialLinks } =
+  const { name, team, position, bio, image, isTeamLeader, socialLinks } =
     member.fields;
   const { name: teamName } = team!.fields;
+  // const {  }
 
   return (
-    <div className="w-64">
-      <div className="flex justify-end h-64 mb-2 bg-grey w-100 group">
-        {image && (
-          <div className="relative w-full filter grayscale group-hover:grayscale-0">
-            <ContentfulImage
-              downloadWidth={500}
-              image={image}
-              alt={name}
-              priority={isTeamLeader}
-            />
-            <div
-              className={
-                'left-0 top-0 w-full h-full absolute opacity-0 group-hover:opacity-10'
-              }
-              style={{
-                backgroundColor: teamColor,
-              }}
-            />
-          </div>
-        )}
-        <div
-          style={{ backgroundColor: teamColor }}
-          className={'absolute w-8 h-8'}
-        />
-      </div>
-      <div className="font-bold">{name}</div>
-      <div>
-        <span className="mx-1">{position};</span>
-        <div style={{ color: teamColor }} className="font-bold uppercase">
-          {teamName}
-        </div>
-      </div>
-      {socialLinks && (
-        <div className="mt-2">
-          <SocialLinks
-            socialLinks={socialLinks.fields}
-            className="justify-center"
+    <div className="flex flex-row">
+      <div className="flex-none w-64 h-64">
+        <div className="flex justify-end h-64 mb-2 bg-grey w-100 group">
+          {image && (
+            <div className="relative w-full filter grayscale group-hover:grayscale-0">
+              <ContentfulImage
+                downloadWidth={500}
+                image={image}
+                alt={name}
+                priority={isTeamLeader}
+              />
+              <div
+                className={
+                  'left-0 top-0 w-full h-full absolute opacity-0 group-hover:opacity-10'
+                }
+                style={{
+                  backgroundColor: teamColor,
+                }}
+              />
+            </div>
+          )}
+          <div
+            style={{ backgroundColor: teamColor }}
+            className={'absolute w-8 h-8'}
           />
         </div>
-      )}
-    </div>
-  );
-};
-
-const TeamSelector: React.FC<{
-  teams: ITeam[];
-  selectedTeam: string | null;
-}> = ({ teams, selectedTeam }) => {
-  const [hovered, setHovered] = useState<string | null>();
-
-  const getBackgroundColor = (slug: string, color: string) => {
-    if (selectedTeam === slug || hovered === slug) {
-      return color;
-    }
-    return undefined;
-  };
-
-  return (
-    <div className="flex flex-wrap justify-center max-w-6xl m-auto mb-10">
-      {teams
-        .map((t) => t.fields)
-        .map(({ name, color, icon, sprite, slug }) => (
-          <Link key={slug} href={{ hash: slug }}>
-            <a
-              style={{ backgroundColor: getBackgroundColor(slug, color) }}
-              className={'w-20 h-20 flex-grow-0 transition-colors'}
-              onPointerEnter={() => setHovered(slug)}
-              onPointerLeave={() =>
-                setHovered((curr) => (curr === slug ? null : curr))
-              }
-            >
-              {sprite ? (
-                <ContentfulImage
-                  image={sprite}
-                  alt={name}
-                  width={75}
-                  height={75}
-                  priority
-                />
-              ) : (
-                <div className="text-4xl">{icon}</div>
-              )}
-            </a>
-          </Link>
-        ))}
+      </div>
+      <div className="grow justify text-left mx-6">
+        <div className="text-xl font-bold">{name}</div>
+        <div>
+          <span className="font-bold uppercase text-gray-400">{position}</span>
+          <span className="mx-1 text-gray-400">&bull;</span>
+          <span style={{ color: teamColor }} className="font-bold uppercase">
+            {teamName}
+          </span>
+          <div className="mt-2 text-sm">
+            <RichText document={bio} />
+          </div>
+        </div>
+        {socialLinks && (
+          <div>
+            <SocialLinks socialLinks={socialLinks.fields} className="mt-2" />
+          </div>
+        )}
+      </div>
     </div>
   );
 };
@@ -161,16 +123,14 @@ const MemberList: React.FC<{ members: ITeamMember[]; teams: ITeam[] }> = ({
 
   return (
     <div className="md:mx-auto md:w-4/6">
-      <div className="flex flex-wrap justify-center">
-        {members.map((m) => (
-          <div className="m-5" key={m.sys.id}>
-            <TeamMemberCard
-              member={m}
-              teamColor={colorMap[m.fields.team!.fields.name]}
-            />
-          </div>
-        ))}
-      </div>
+      {members.map((m) => (
+        <div className="m-5" key={m.sys.id}>
+          <TeamMemberCard
+            member={m}
+            teamColor={colorMap[m.fields.team!.fields.name]}
+          />
+        </div>
+      ))}
     </div>
   );
 };
@@ -243,14 +203,7 @@ const Team: PageWithLayout<TeamProps> = ({ teams, teamMembers }) => {
   return (
     <>
       <NextSeo title="Our Team" />
-      <FirstSubSection header="Our team">
-        We&apos;re so grateful to have so many passionate vegan volunteers with
-        us supporting the movement! Each team below is run independently from
-        each other and are assigned to different projects or organizations.{' '}
-        <b>Please click one of the icons below!</b>
-      </FirstSubSection>
       <div className="m-10">
-        <TeamSelector selectedTeam={team} teams={shuffledTeams} />
         <MemberList members={members} teams={teams} />
         {members.length < totalMembers && (
           <div className="mt-10 flex justify-center">

--- a/src/pages/people/team.tsx
+++ b/src/pages/people/team.tsx
@@ -48,63 +48,100 @@ export const getStaticProps: GetStaticProps = async () => {
   };
 };
 
-const TeamMemberCard: React.FC<{ member: ITeamMember; teamColor: string }> = ({
-  member,
-  teamColor,
-}) => {
-  const { name, team, position, bio, image, isTeamLeader, socialLinks } =
-    member.fields;
-  const { name: teamName } = team!.fields;
-  // const {  }
+const TeamMemberCardPhoto: React.FC<{
+  member: ITeamMember;
+  teamColor: string;
+}> = ({ member, teamColor }) => {
+  const { name, image, isTeamLeader } = member.fields;
 
   return (
-    <div className="flex flex-row">
-      <div className="flex-none w-64 h-64">
-        <div className="flex justify-end h-64 mb-2 bg-grey w-100 group">
-          {image && (
-            <div className="relative w-full filter grayscale group-hover:grayscale-0">
-              <ContentfulImage
-                downloadWidth={500}
-                image={image}
-                alt={name}
-                priority={isTeamLeader}
-              />
-              <div
-                className={
-                  'left-0 top-0 w-full h-full absolute opacity-0 group-hover:opacity-10'
-                }
-                style={{
-                  backgroundColor: teamColor,
-                }}
-              />
-            </div>
-          )}
-          <div
-            style={{ backgroundColor: teamColor }}
-            className={'absolute w-8 h-8'}
-          />
-        </div>
-      </div>
-      <div className="grow justify text-left mx-6">
-        <div className="text-xl font-bold">{name}</div>
-        <div>
-          <span className="font-bold uppercase text-gray-400">{position}</span>
-          <span className="mx-1 text-gray-400">&bull;</span>
-          <span style={{ color: teamColor }} className="font-bold uppercase">
-            {teamName}
-          </span>
-          <div className="mt-2 text-sm">
-            <RichText document={bio} />
-          </div>
-        </div>
-        {socialLinks && (
-          <div>
-            <SocialLinks socialLinks={socialLinks.fields} className="mt-2" />
+    <div className="flex-none mx-4 w-64 h-64">
+      <div className="flex justify-end h-64 mb-2 bg-grey w-100 group">
+        {image && (
+          <div className="relative w-full filter grayscale group-hover:grayscale-0">
+            <ContentfulImage
+              downloadWidth={500}
+              image={image}
+              alt={name}
+              priority={isTeamLeader}
+            />
+            <div
+              className={
+                'left-0 top-0 w-full h-full absolute opacity-0 group-hover:opacity-10'
+              }
+              style={{
+                backgroundColor: teamColor,
+              }}
+            />
           </div>
         )}
+        <div
+          style={{ backgroundColor: teamColor }}
+          className={'absolute w-8 h-8'}
+        />
       </div>
     </div>
   );
+};
+
+const TeamMemberCardBody: React.FC<{
+  member: ITeamMember;
+  teamColor: string;
+}> = ({ member, teamColor }) => {
+  const { name, team, position, bio, socialLinks } = member.fields;
+  const { name: teamName } = team!.fields;
+
+  return (
+    <div className="grow shrink lg:text-left mx-4 justify-center lg:justify-start">
+      <div className="text-xl font-bold text-grey">{name}</div>
+      <div>
+        <span className="font-bold uppercase text-grey-light">{position}</span>
+        <span className="mx-1 text-grey-light">&bull;</span>
+        <span style={{ color: teamColor }} className="font-bold uppercase">
+          {teamName}
+        </span>
+        <div className="mt-2 text-sm">
+          <RichText document={bio} />
+        </div>
+      </div>
+      {socialLinks && (
+        <div>
+          <SocialLinks socialLinks={socialLinks.fields} className="mt-2" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+const TeamMemberCard: React.FC<{
+  member: ITeamMember;
+  teamColor: string;
+  showPhotoFirst: boolean;
+  showDividerBelow: boolean;
+}> = ({ member, teamColor, showPhotoFirst, showDividerBelow }) => {
+  if (showPhotoFirst) {
+    return (
+      <div
+        className={`flex flex-wrap lg:flex-nowrap justify-center lg:justify-start pb-8 mb-0 border-grey-light ${
+          showDividerBelow ? 'border-b-2' : ''
+        }`}
+      >
+        <TeamMemberCardPhoto member={member} teamColor={teamColor} />
+        <TeamMemberCardBody member={member} teamColor={teamColor} />
+      </div>
+    );
+  } else {
+    return (
+      <div
+        className={`flex flex-wrap-reverse lg:flex-nowrap justify-center lg:justify-start pb-8 mb-0 border-grey-light ${
+          showDividerBelow ? 'border-b-2' : ''
+        }`}
+      >
+        <TeamMemberCardBody member={member} teamColor={teamColor} />
+        <TeamMemberCardPhoto member={member} teamColor={teamColor} />
+      </div>
+    );
+  }
 };
 
 const MemberList: React.FC<{ members: ITeamMember[]; teams: ITeam[] }> = ({
@@ -123,11 +160,13 @@ const MemberList: React.FC<{ members: ITeamMember[]; teams: ITeam[] }> = ({
 
   return (
     <div className="md:mx-auto md:w-4/6">
-      {members.map((m) => (
+      {members.map((m, index) => (
         <div className="m-5" key={m.sys.id}>
           <TeamMemberCard
             member={m}
             teamColor={colorMap[m.fields.team!.fields.name]}
+            showPhotoFirst={!(index % 2)}
+            showDividerBelow={index + 1 < members.length}
           />
         </div>
       ))}

--- a/src/pages/people/team.tsx
+++ b/src/pages/people/team.tsx
@@ -31,6 +31,7 @@ export const getStaticProps: GetStaticProps = async () => {
       filters: {
         exists: {
           team: true,
+          isCoreMember: true,
         },
         ne: {
           isInactive: true,

--- a/src/pages/people/volunteers.tsx
+++ b/src/pages/people/volunteers.tsx
@@ -1,0 +1,288 @@
+import { NextSeo } from 'next-seo';
+import Link from 'next/link';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import PeopleLayout from '../../components/layout/people';
+import { FirstSubSection } from '../../components/decoration/textBlocks';
+import { WhiteButton } from '../../components/decoration/buttons';
+import { getContents } from '../../lib/cms';
+import SquareField from '../../components/decoration/squares';
+import { getActiveTeams } from '../../lib/cms/helpers';
+import ContentfulImage from '../../components/layout/contentfulImage';
+import { useHash } from '../../hooks/useHash';
+import shuffle from '../../lib/helpers/shuffle';
+import useViewMore from '../../hooks/useViewMore';
+import CustomImage from '../../components/decoration/customImage';
+import SocialLinks from '../../components/layout/team/socialLinks';
+import { pixelHeart } from '../../images/separators';
+
+import type PageWithLayout from '../../types/persistentLayout';
+import type { ITeamFields } from '../../types/generated/contentful';
+import type { ITeamMember } from '../../types/generated/contentful';
+import type { ITeam } from '../../types/generated/contentful';
+import type { GetStaticProps } from 'next';
+
+export const getStaticProps: GetStaticProps = async () => {
+  const teams = await getActiveTeams();
+  const teamMembers = await getContents<ITeamFields>({
+    contentType: 'teamMember',
+    query: {
+      type: 'team',
+      filters: {
+        exists: {
+          team: true,
+        },
+        ne: {
+          isInactive: true,
+          isCoreMember: true,
+        },
+      },
+    },
+    other: { order: 'fields.isTeamLeader' },
+  });
+
+  return {
+    props: { teams, teamMembers },
+    revalidate: 480,
+  };
+};
+
+const TeamMemberCard: React.FC<{ member: ITeamMember; teamColor: string }> = ({
+  member,
+  teamColor,
+}) => {
+  const { name, team, position, image, isTeamLeader, socialLinks } =
+    member.fields;
+  const { name: teamName } = team!.fields;
+
+  return (
+    <div className="w-64">
+      <div className="flex justify-end h-64 mb-2 bg-grey w-100 group">
+        {image && (
+          <div className="relative w-full filter grayscale group-hover:grayscale-0">
+            <ContentfulImage
+              downloadWidth={500}
+              image={image}
+              alt={name}
+              priority={isTeamLeader}
+            />
+            <div
+              className={
+                'left-0 top-0 w-full h-full absolute opacity-0 group-hover:opacity-10'
+              }
+              style={{
+                backgroundColor: teamColor,
+              }}
+            />
+          </div>
+        )}
+        <div
+          style={{ backgroundColor: teamColor }}
+          className={'absolute w-8 h-8'}
+        />
+      </div>
+      <div className="font-bold">{name}</div>
+      <div>
+        <span className="mx-1">{position};</span>
+        <div style={{ color: teamColor }} className="font-bold uppercase">
+          {teamName}
+        </div>
+      </div>
+      {socialLinks && (
+        <div className="mt-2">
+          <SocialLinks
+            socialLinks={socialLinks.fields}
+            className="justify-center"
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+const TeamSelector: React.FC<{
+  teams: ITeam[];
+  selectedTeam: string | null;
+}> = ({ teams, selectedTeam }) => {
+  const [hovered, setHovered] = useState<string | null>();
+
+  const getBackgroundColor = (slug: string, color: string) => {
+    if (selectedTeam === slug || hovered === slug) {
+      return color;
+    }
+    return undefined;
+  };
+
+  return (
+    <div className="flex flex-wrap justify-center max-w-6xl m-auto mb-10">
+      {teams
+        .map((t) => t.fields)
+        .map(({ name, color, icon, sprite, slug }) => (
+          <Link key={slug} href={{ hash: slug }}>
+            <a
+              style={{ backgroundColor: getBackgroundColor(slug, color) }}
+              className={'w-20 h-20 flex-grow-0 transition-colors'}
+              onPointerEnter={() => setHovered(slug)}
+              onPointerLeave={() =>
+                setHovered((curr) => (curr === slug ? null : curr))
+              }
+            >
+              {sprite ? (
+                <ContentfulImage
+                  image={sprite}
+                  alt={name}
+                  width={75}
+                  height={75}
+                  priority
+                />
+              ) : (
+                <div className="text-4xl">{icon}</div>
+              )}
+            </a>
+          </Link>
+        ))}
+    </div>
+  );
+};
+
+const MemberList: React.FC<{ members: ITeamMember[]; teams: ITeam[] }> = ({
+  members,
+  teams,
+}) => {
+  const colorMap = useMemo(() => {
+    if (!teams) return {};
+    return teams.reduce((acc, curr) => {
+      const { name: teamName, color } = curr.fields;
+
+      acc[teamName] = color;
+      return acc;
+    }, {} as Record<string, string>);
+  }, [teams]);
+
+  return (
+    <div className="md:mx-auto md:w-4/6">
+      <div className="flex flex-wrap justify-center">
+        {members.map((m) => (
+          <div className="m-5" key={m.sys.id}>
+            <TeamMemberCard
+              member={m}
+              teamColor={colorMap[m.fields.team!.fields.name]}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const useFilteredMembers = (
+  allMembers: ITeamMember[],
+  selectedTeam: string | null,
+  pageSize: number,
+  pageNumber: number
+) => {
+  return useMemo(() => {
+    const filteredByTeam = selectedTeam
+      ? allMembers.filter((p) => {
+          return p.fields.team?.fields.slug === selectedTeam;
+        })
+      : allMembers;
+
+    const paged = filteredByTeam.slice(0, pageSize * pageNumber);
+
+    return {
+      members: paged,
+      totalMembers: filteredByTeam.length,
+    };
+  }, [allMembers, selectedTeam, pageSize, pageNumber]);
+};
+
+const TEAM_SQUARES = [
+  { color: 'grey-light', size: 16, left: 0, bottom: 0 },
+  { color: 'grey-lighter', size: 16, left: 16, top: 0 },
+  { color: 'grey-light', size: 16, right: 0, bottom: 0 },
+  { color: 'white', size: 16, right: 0, top: 0 },
+];
+
+interface TeamProps {
+  teams: ITeam[];
+  teamMembers: ITeamMember[];
+}
+
+const Team: PageWithLayout<TeamProps> = ({ teams, teamMembers }) => {
+  const [team] = useHash();
+
+  const [shuffledTeams, setShuffledTeams] = useState<ITeam[]>([]);
+  const [shuffledTeamMembers, setShuffledTeamMembers] = useState<ITeamMember[]>(
+    []
+  );
+
+  const { pageNumber, pageSize, viewMore } = useViewMore();
+  const { members, totalMembers } = useFilteredMembers(
+    shuffledTeamMembers,
+    team,
+    pageSize,
+    pageNumber
+  );
+
+  useEffect(() => {
+    setShuffledTeams(shuffle(teams));
+  }, [teams]);
+
+  useEffect(() => {
+    setShuffledTeamMembers([
+      ...shuffle<ITeamMember>(
+        teamMembers.filter((member) => member.fields.isTeamLeader)
+      ),
+      ...shuffle<ITeamMember>(
+        teamMembers.filter((member) => !member.fields.isTeamLeader)
+      ),
+    ]);
+  }, [teamMembers]);
+
+  return (
+    <>
+      <NextSeo title="Our Volunteers" />
+      <FirstSubSection header="Our volunteers">
+        We&apos;re so grateful to have so many passionate vegan volunteers with
+        us supporting the movement! Each team below is run independently from
+        each other and are assigned to different projects or organizations.{' '}
+        <b>Please click one of the icons below!</b>
+      </FirstSubSection>
+      <div className="m-10">
+        <TeamSelector selectedTeam={team} teams={shuffledTeams} />
+        <MemberList members={members} teams={teams} />
+        {members.length < totalMembers && (
+          <div className="mt-10 flex justify-center">
+            <WhiteButton
+              className="content-center font-mono text-2xl"
+              onClick={() => viewMore()}
+            >
+              Load more
+            </WhiteButton>
+          </div>
+        )}
+      </div>
+      <SquareField squares={TEAM_SQUARES} className="hidden md:block" />
+      <div className="px-10 pt-16 pb-10 bg-gray-background">
+        <CustomImage
+          src={pixelHeart.src}
+          width={pixelHeart.width / 3}
+          height={pixelHeart.height / 3}
+          alt="Our community"
+        />
+        <FirstSubSection header="Our community">
+          We’re not just volunteers, but we’re a community. We know each other
+          personally, we play games together, talk about our lives, meet up in
+          person at events, and share daily. A strong community is not only key
+          for a volunteer organization, it’s vital to keeping us happy, healthy,
+          and active for the animals. Interested in joining? Scroll down!
+        </FirstSubSection>
+      </div>
+    </>
+  );
+};
+
+Team.Layout = PeopleLayout;
+
+export default Team;

--- a/src/pages/people/volunteers.tsx
+++ b/src/pages/people/volunteers.tsx
@@ -27,6 +27,7 @@ export const getStaticProps: GetStaticProps = async () => {
   const teamMembers = await getContents<ITeamFields>({
     contentType: 'teamMember',
     query: {
+      isCoreMember: false,
       type: 'team',
       filters: {
         exists: {
@@ -34,7 +35,6 @@ export const getStaticProps: GetStaticProps = async () => {
         },
         ne: {
           isInactive: true,
-          isCoreMember: true,
         },
       },
     },


### PR DESCRIPTION
**This pull request delivers the following functionality:**

1. Introduces a new Our team page at the previous page's address that shows the executive team.
2. Renames the existing team page as volunteers.
3. Adds a new tab after Our team on the people pages called Volunteers that points to the volunteers page.

**Known issues:**

1. The grey colours don't exactly match the grey in the design.
2. The dividers between people are wider than the people sections themselves.

**Screenshots:**
_Desktop_
<img width="300" alt="image" src="https://user-images.githubusercontent.com/4416238/193941454-8b8a4d48-c510-4e4e-a864-a0caeeb7c6a7.png">

_Mobile_
<img width="300" alt="Screenshot 2022-10-04 at 23 27 15" src="https://user-images.githubusercontent.com/4416238/193941634-e40ebe4e-5950-4ca7-b5b5-b5c7b8875f4b.png">
