### PR TITLE
Scroll to top on project select

### DIFF
--- a/src/pages/data/index.tsx
+++ b/src/pages/data/index.tsx
@@ -41,6 +41,7 @@ const Data: React.FC = () => {
   const [dataDisplayed, displayData] = useState(false);
   const changeProject = () => {
     displayData(true);
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
   };
 
   const dataSquares = {


### PR DESCRIPTION
Fix an issue where on the `/data` page if you select a project and the page is scrolled down, the dashboard will open but the page will still be scrolled down.

## Fixed demo

https://user-images.githubusercontent.com/39889198/194325281-75dd517e-da3d-48db-8eaa-2eda973f1d58.mov

