### PR TITLE
Fix hearts not always showing on sprite click

### DIFF
--- a/src/components/decoration/sprite/FloatingHeart.tsx
+++ b/src/components/decoration/sprite/FloatingHeart.tsx
@@ -39,7 +39,7 @@ const FloatingHeart: React.FC<FloatingHeartProps> = ({
         setLeft(parseFloat(position.get()));
       }, delay);
     }
-  }, [float, floating, delay, position]);
+  }, [float, delay, position]);
 
   return (
     <div


### PR DESCRIPTION
Hearts seemed to stop appearing if the sprite is clicked before the hearts have finished their animation. The break caused the `floating` state in `FloatingHeart.tsx` to get stuck in true so it never resets.

If the duration of the sprite animation was increased to longer than the heart animation then the hearts only ever appeared after the first click and then never work again.

`FloatingHeart.tsx` seemed to get caught in a loop. `onAnimationEnd` set `floating` to false, which updated the state and reruns the `useEffect` and now `floating` is false so the process of setting `floating` to true started again unnecessarily. Removing `floating` as a `useEffect` dependency stops `useEffect` triggering when `floating` updates and should stop any looping.

ESLint is upset that `floating` is used in the `useEffect` but isn't a dependency though, so let me know if someone knows how best to fix that.