### PR TITLE
Update Playground Admin

### DIFF
--- a/src/components/layout/playground/requests/requestCard.tsx
+++ b/src/components/layout/playground/requests/requestCard.tsx
@@ -2,6 +2,7 @@ import { faClock } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { useMemo } from 'react';
 import classNames from 'classnames';
+import { Status } from '@prisma/client';
 import { useSession } from 'next-auth/react';
 
 import {
@@ -63,6 +64,7 @@ const PlaygroundRequestCard: React.FC<
     organization,
     budget,
     dueDate,
+    status,
   },
   children,
 }) => {
@@ -84,7 +86,8 @@ const PlaygroundRequestCard: React.FC<
   );
   const { data: session } = useSession();
   const canEdit =
-    session?.user?.role === 'Admin' || requester?.id === session?.user?.id;
+    status !== Status.Completed &&
+    (session?.user?.role === 'Admin' || requester?.id === session?.user?.id);
 
   return (
     <div
@@ -174,7 +177,11 @@ const PlaygroundRequestCard: React.FC<
               canEdit ? 'w-1/2' : ''
             }`}
           >
-            Read more / apply
+            Read more{' '}
+            {session?.user?.role !== 'Admin' &&
+            requester?.id !== session?.user?.id
+              ? '/ apply'
+              : null}
           </DarkButton>
           {canEdit && (
             <GreyButton

--- a/src/components/layout/playground/requests/requestCard.tsx
+++ b/src/components/layout/playground/requests/requestCard.tsx
@@ -177,7 +177,7 @@ const PlaygroundRequestCard: React.FC<
               canEdit ? 'w-1/2' : ''
             }`}
           >
-                        {`Read more${
+            {`Read more${
               session?.user?.role !== 'Admin' &&
               requester?.id !== session?.user?.id
                 ? ' / apply'

--- a/src/components/layout/playground/requests/requestCard.tsx
+++ b/src/components/layout/playground/requests/requestCard.tsx
@@ -177,11 +177,12 @@ const PlaygroundRequestCard: React.FC<
               canEdit ? 'w-1/2' : ''
             }`}
           >
-            Read more{' '}
-            {session?.user?.role !== 'Admin' &&
-            requester?.id !== session?.user?.id
-              ? '/ apply'
-              : null}
+                        {`Read more${
+              session?.user?.role !== 'Admin' &&
+              requester?.id !== session?.user?.id
+                ? ' / apply'
+                : ''
+            }`}
           </DarkButton>
           {canEdit && (
             <GreyButton

--- a/src/pages/playground/admin/applications.tsx
+++ b/src/pages/playground/admin/applications.tsx
@@ -59,7 +59,7 @@ const AdminPage: NextPage = ({}) => {
                 href={{ pathname: '/playground/admin', query: { status } }}
                 key={status}
               >
-                {status} requests
+                {status === 'Accepted' ? 'Live' : status} requests
               </OutlineButton>
             ))}
           <OutlineButton

--- a/src/pages/playground/admin/index.tsx
+++ b/src/pages/playground/admin/index.tsx
@@ -142,70 +142,74 @@ const AdminPage: NextPage = () => {
                     )}
                   </b>
                 )}
-                <div className="grid grid-cols-1 gap-x-5 gap-y-2 md:grid-cols-2">
-                  <LightButton
-                    className="w-full"
-                    disabled={
-                      isMutationLoading || request.status === Status.Accepted
-                    }
-                    onClick={() => {
-                      if (
-                        confirm(
-                          `Are you sure you want to accept '${request.title}'?`
-                        )
-                      ) {
-                        mutate({ id: request.id, status: 'Accepted' });
-                      }
-                    }}
-                  >
-                    Accept
-                  </LightButton>
-                  <DenyButton
-                    className="w-full text-xl text-white"
-                    disabled={isMutationLoading}
-                    onClick={() => {
-                      if (
-                        confirm(
-                          `Are you sure you want to reject '${request.title}'?`
-                        )
-                      ) {
-                        mutate({ id: request.id, status: 'Rejected' });
-                      }
-                    }}
-                  >
-                    Deny
-                  </DenyButton>
-                  <ExternalLinkButton
-                    className="w-full px-2 text-xl text-white"
-                    disabled={isDeletionLoading}
-                    onClick={() => {
-                      if (
-                        confirm(
-                          `Are you sure you want to delete '${request.title}'?`
-                        )
-                      ) {
-                        mutateDelete({ id: request.id });
-                      }
-                    }}
-                  >
-                    🤫 Delete
-                  </ExternalLinkButton>
-                  <GreenButton
-                    className="w-full px-2 text-xl"
-                    disabled={isMutationLoading}
-                    onClick={() => {
-                      if (
-                        confirm(
-                          `Are you sure you want to complete '${request.title}'?`
-                        )
-                      ) {
-                        mutate({ id: request.id, status: Status.Completed });
-                      }
-                    }}
-                  >
-                    🎉 Mark as completed
-                  </GreenButton>
-                </div>
+                {request.status !== Status.Completed ? (
+                  <div className="grid grid-cols-1 gap-x-5 gap-y-2 md:grid-cols-2">
+                    {request.status !== Status.Accepted ? (
+                      <>
+                        <LightButton
+                          className="w-full"
+                          disabled={isMutationLoading}
+                          onClick={() => {
+                            if (
+                              confirm(
+                                `Are you sure you want to accept '${request.title}'?`
+                              )
+                            ) {
+                              mutate({ id: request.id, status: 'Accepted' });
+                            }
+                          }}
+                        >
+                          Accept
+                        </LightButton>
+                        <DenyButton
+                          className="w-full text-xl text-white"
+                          disabled={isMutationLoading}
+                          onClick={() => {
+                            if (
+                              confirm(
+                                `Are you sure you want to reject '${request.title}'?`
+                              )
+                            ) {
+                              mutate({ id: request.id, status: 'Rejected' });
+                            }
+                          }}
+                        >
+                          Deny
+                        </DenyButton>{' '}
+                      </>
+                    ) : null}
+                    <ExternalLinkButton
+                      className="w-full px-2 text-xl text-white"
+                      disabled={isDeletionLoading}
+                      onClick={() => {
+                        if (
+                          confirm(
+                            `Are you sure you want to delete '${request.title}'?`
+                          )
+                        ) {
+                          mutateDelete({ id: request.id });
+                        }
+                      }}
+                    >
+                      🤫 Delete
+                    </ExternalLinkButton>
+                    <GreenButton
+                      className="w-full px-2 text-xl"
+                      disabled={isMutationLoading}
+                      onClick={() => {
+                        if (
+                          confirm(
+                            `Are you sure you want to complete '${request.title}'?`
+                          )
+                        ) {
+                          mutate({ id: request.id, status: Status.Completed });
+                        }
+                      }}
+                    >
+                      🎉 Mark as completed
+                    </GreenButton>
+                  </div>
+                ) : null}
               </PlaygroundRequestCard>
             </div>
           ))}

--- a/src/pages/playground/admin/index.tsx
+++ b/src/pages/playground/admin/index.tsx
@@ -142,57 +142,58 @@ const AdminPage: NextPage = () => {
                     )}
                   </b>
                 )}
-                {request.status !== Status.Completed ? (
-                  <div className="grid grid-cols-1 gap-x-5 gap-y-2 md:grid-cols-2">
-                    {request.status !== Status.Accepted ? (
-                      <>
-                        <LightButton
-                          className="w-full"
-                          disabled={isMutationLoading}
-                          onClick={() => {
-                            if (
-                              confirm(
-                                `Are you sure you want to accept '${request.title}'?`
-                              )
-                            ) {
-                              mutate({ id: request.id, status: 'Accepted' });
-                            }
-                          }}
-                        >
-                          Accept
-                        </LightButton>
-                        <DenyButton
-                          className="w-full text-xl text-white"
-                          disabled={isMutationLoading}
-                          onClick={() => {
-                            if (
-                              confirm(
-                                `Are you sure you want to reject '${request.title}'?`
-                              )
-                            ) {
-                              mutate({ id: request.id, status: 'Rejected' });
-                            }
-                          }}
-                        >
-                          Deny
-                        </DenyButton>{' '}
-                      </>
-                    ) : null}
-                    <ExternalLinkButton
-                      className="w-full px-2 text-xl text-white"
-                      disabled={isDeletionLoading}
-                      onClick={() => {
-                        if (
-                          confirm(
-                            `Are you sure you want to delete '${request.title}'?`
-                          )
-                        ) {
-                          mutateDelete({ id: request.id });
-                        }
-                      }}
-                    >
-                      🤫 Delete
-                    </ExternalLinkButton>
+
+                <div className="grid grid-cols-1 gap-x-5 gap-y-2 md:grid-cols-2">
+                  {request.status === Status.Pending ? (
+                    <>
+                      <LightButton
+                        className="w-full"
+                        disabled={isMutationLoading}
+                        onClick={() => {
+                          if (
+                            confirm(
+                              `Are you sure you want to accept '${request.title}'?`
+                            )
+                          ) {
+                            mutate({ id: request.id, status: 'Accepted' });
+                          }
+                        }}
+                      >
+                        Accept
+                      </LightButton>
+                      <DenyButton
+                        className="w-full text-xl text-white"
+                        disabled={isMutationLoading}
+                        onClick={() => {
+                          if (
+                            confirm(
+                              `Are you sure you want to reject '${request.title}'?`
+                            )
+                          ) {
+                            mutate({ id: request.id, status: 'Rejected' });
+                          }
+                        }}
+                      >
+                        Deny
+                      </DenyButton>{' '}
+                    </>
+                  ) : null}
+                  <ExternalLinkButton
+                    className="w-full px-2 text-xl text-white"
+                    disabled={isDeletionLoading}
+                    onClick={() => {
+                      if (
+                        confirm(
+                          `Are you sure you want to delete '${request.title}'?`
+                        )
+                      ) {
+                        mutateDelete({ id: request.id });
+                      }
+                    }}
+                  >
+                    🤫 Delete
+                  </ExternalLinkButton>
+                  {request.status !== Status.Completed ? (
                     <GreenButton
                       className="w-full px-2 text-xl"
                       disabled={isMutationLoading}
@@ -208,8 +209,8 @@ const AdminPage: NextPage = () => {
                     >
                       🎉 Mark as completed
                     </GreenButton>
-                  </div>
-                ) : null}
+                  ) : null}
+                </div>
               </PlaygroundRequestCard>
             </div>
           ))}

--- a/src/pages/playground/admin/index.tsx
+++ b/src/pages/playground/admin/index.tsx
@@ -86,7 +86,7 @@ const AdminPage: NextPage = () => {
             setStatusFilter(status);
           }}
         >
-          {status} requests
+          {status === 'Accepted' ? 'Live' : status} requests
         </OutlineButton>
       );
     },


### PR DESCRIPTION
- Hide 'Accept' & 'Deny' buttons when the request is already accepted
- Hide 'Accept', 'Deny', 'Delete', and 'Mark As Completed' buttons when the request is already completed
- Hide '/ apply' text on the 'Read more / apply' button when it is viewed by an admin or the request submitter 
- Rename 'Accepted' tab to 'Live' (Not sure I've correctly just changed what the UI says, or if I should change all mention of 'Accepted' in the data?)