### PR TITLE
Add URL Parameters to Playground Request Filters

### DIFF
--- a/src/components/layout/playground/requests/filters.tsx
+++ b/src/components/layout/playground/requests/filters.tsx
@@ -257,8 +257,6 @@ const RequestFilters: React.FC<RequestFiltersProps> = ({
 }) => {
   const { sort, ...otherFilters } = filters;
 
-  const router = useRouter();
-
   return (
     <div
       className={classNames(
@@ -279,24 +277,6 @@ const RequestFilters: React.FC<RequestFiltersProps> = ({
           filters={otherFilters}
           onFiltersChange={(newFilters) => {
             onChange({ sort: filters.sort, ...newFilters });
-            delete router.query['isPaidRequest'];
-            delete router.query['category'];
-            void router.push(
-              {
-                pathname: router.pathname,
-                query: {
-                  ...(newFilters.categories && {
-                    category: newFilters.categories,
-                  }),
-                  ...(typeof newFilters.isPaidRequest === 'boolean' && {
-                    isPaidRequest: newFilters.isPaidRequest,
-                  }),
-                  ...router.query,
-                },
-              },
-              undefined,
-              { shallow: true }
-            );
           }}
         />
       </div>

--- a/src/components/layout/playground/requests/filters.tsx
+++ b/src/components/layout/playground/requests/filters.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
 import { PlaygroundRequestCategory } from '@prisma/client';
 import classNames from 'classnames';
 
@@ -256,6 +257,8 @@ const RequestFilters: React.FC<RequestFiltersProps> = ({
 }) => {
   const { sort, ...otherFilters } = filters;
 
+  const router = useRouter();
+
   return (
     <div
       className={classNames(
@@ -274,9 +277,27 @@ const RequestFilters: React.FC<RequestFiltersProps> = ({
         </span>
         <FilterBy
           filters={otherFilters}
-          onFiltersChange={(newFilters) =>
-            onChange({ sort: filters.sort, ...newFilters })
-          }
+          onFiltersChange={(newFilters) => {
+            onChange({ sort: filters.sort, ...newFilters });
+            delete router.query['isPaidRequest'];
+            delete router.query['category'];
+            void router.push(
+              {
+                pathname: router.pathname,
+                query: {
+                  ...(newFilters.categories && {
+                    category: newFilters.categories,
+                  }),
+                  ...(typeof newFilters.isPaidRequest === 'boolean' && {
+                    isPaidRequest: newFilters.isPaidRequest,
+                  }),
+                  ...router.query,
+                },
+              },
+              undefined,
+              { shallow: true }
+            );
+          }}
         />
       </div>
       <div

--- a/src/pages/playground/index.tsx
+++ b/src/pages/playground/index.tsx
@@ -1,11 +1,13 @@
 import { NextSeo } from 'next-seo';
 import React, { useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
 import {
   faLongArrowAltLeft as leftArrow,
   faLongArrowAltRight as rightArrow,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
+import { PlaygroundRequestCategory } from '@prisma/client';
 
 import { useExtendedPagination } from '../../hooks/useExtendedPagination';
 
@@ -23,9 +25,33 @@ import { trpc } from 'lib/client/trpc';
 import type PageWithLayout from 'types/persistentLayout';
 
 const Playground: PageWithLayout = ({}) => {
+  const router = useRouter();
+
+  const isCategories = (
+    value: string | string[] | undefined
+  ): value is trpc['playground']['getAllRequests']['input']['categories'] => {
+    if (value === undefined) {
+      return true;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((category) => {
+        if (!(category in PlaygroundRequestCategory)) return false;
+      });
+      return true;
+    }
+    return value in PlaygroundRequestCategory && true;
+  };
+
   const [filters, setFilters] = useState<
     trpc['playground']['getAllRequests']['input']
   >(() => ({
+    categories: isCategories(router.query.category)
+      ? router.query.category
+      : undefined,
+    isPaidRequest:
+      router.query.isPaidRequest !== undefined
+        ? router.query.isPaidRequest === 'true'
+        : undefined,
     sort: {
       createdAt: 'desc',
     },

--- a/src/pages/playground/index.tsx
+++ b/src/pages/playground/index.tsx
@@ -24,34 +24,26 @@ import { trpc } from 'lib/client/trpc';
 
 import type PageWithLayout from 'types/persistentLayout';
 
+const isValidPlaygroundRequestCategoryValue = (
+  value: string | string[] | undefined
+): value is PlaygroundRequestCategory[] => {
+  if (value === undefined) return false;
+  if (Array.isArray(value)) {
+    return value.some((category) => category in PlaygroundRequestCategory);
+  }
+  return value in PlaygroundRequestCategory;
+};
+
 const Playground: PageWithLayout = ({}) => {
   const router = useRouter();
-
-  const isCategories = (
-    value: string | string[] | undefined
-  ): value is trpc['playground']['getAllRequests']['input']['categories'] => {
-    if (value === undefined) {
-      return true;
-    }
-    if (Array.isArray(value)) {
-      value.forEach((category) => {
-        if (!(category in PlaygroundRequestCategory)) return false;
-      });
-      return true;
-    }
-    return value in PlaygroundRequestCategory && true;
-  };
 
   const [filters, setFilters] = useState<
     trpc['playground']['getAllRequests']['input']
   >(() => ({
-    categories: isCategories(router.query.category)
+    categories: isValidPlaygroundRequestCategoryValue(router.query.category)
       ? router.query.category
       : undefined,
-    isPaidRequest:
-      router.query.isPaidRequest !== undefined
-        ? router.query.isPaidRequest === 'true'
-        : undefined,
+    isPaidRequest: router.query.isPaidRequest === 'true',
     sort: {
       createdAt: 'desc',
     },

--- a/src/pages/playground/index.tsx
+++ b/src/pages/playground/index.tsx
@@ -26,8 +26,10 @@ import type PageWithLayout from 'types/persistentLayout';
 
 const isValidPlaygroundRequestCategoryValue = (
   value: string | string[] | undefined
-): value is PlaygroundRequestCategory[] => {
-  if (value === undefined) return false;
+): value is PlaygroundRequestCategory[] | PlaygroundRequestCategory => {
+  if (value === undefined) {
+    return false;
+  }
   if (Array.isArray(value)) {
     return value.some((category) => category in PlaygroundRequestCategory);
   }
@@ -41,9 +43,13 @@ const Playground: PageWithLayout = ({}) => {
     trpc['playground']['getAllRequests']['input']
   >(() => ({
     categories: isValidPlaygroundRequestCategoryValue(router.query.category)
-      ? router.query.category
+      ? Array.isArray(router.query.category)
+        ? router.query.category
+        : [router.query.category]
       : undefined,
-    isPaidRequest: router.query.isPaidRequest === 'true',
+    ...(router.query.isPaidRequest && {
+      isPaidRequest: router.query.isPaidRequest === 'true',
+    }),
     sort: {
       createdAt: 'desc',
     },
@@ -88,6 +94,33 @@ const Playground: PageWithLayout = ({}) => {
 
   const [animatedRef] = useAutoAnimate<HTMLDivElement>();
 
+  /**
+   * Updates the filters and adds them to the current URL as query strings
+   */
+  const updateFilterHandler = (
+    filters: trpc['playground']['getAllRequests']['input']
+  ) => {
+    delete router.query['isPaidRequest'];
+    delete router.query['category'];
+    void router.push(
+      {
+        pathname: router.pathname,
+        query: {
+          ...(filters.categories && {
+            category: filters.categories,
+          }),
+          ...(typeof filters.isPaidRequest === 'boolean' && {
+            isPaidRequest: filters.isPaidRequest,
+          }),
+          ...router.query,
+        },
+      },
+      undefined,
+      { shallow: true }
+    );
+    setFilters(filters);
+  };
+
   return (
     <>
       <NextSeo title="Requests" />
@@ -105,7 +138,7 @@ const Playground: PageWithLayout = ({}) => {
           className="mb-20 -mt-10 lg:mx-12 2xl:mx-44 xl:mx-36"
           ref={requestContainer}
         >
-          <RequestFilters onChange={setFilters} filters={filters} />
+          <RequestFilters onChange={updateFilterHandler} filters={filters} />
           <div
             className="grid grid-cols-1 gap-8 mx-5 mt-10 md:grid-cols-2"
             ref={animatedRef}


### PR DESCRIPTION
- Added for 'Category' & 'Job Type' filters
- Will avoid having the user re-input their previous filter when navigating back from a help request page

[Trello Ticket](https://trello.com/c/dMkWfFm9/32-store-playground-request-filters-in-url-query)

Feedback would be appreciated for the `isCategories` type guard section.