### PR TITLE
Fix stale help request data when editing

### DIFF
--- a/src/components/layout/playground/submitRequestForm.tsx
+++ b/src/components/layout/playground/submitRequestForm.tsx
@@ -99,10 +99,6 @@ const SubmitRequestForm: React.FC<SubmitRequestFormParam> = ({ requestId }) => {
     { id: requestId, extended: true },
     {
       enabled: !!requestId,
-      cacheTime: 0,
-      onSuccess: () => {
-        setRequestLoaded(true);
-      },
     }
   );
 
@@ -158,6 +154,7 @@ const SubmitRequestForm: React.FC<SubmitRequestFormParam> = ({ requestId }) => {
         setIsFree(false);
         setValue('budget.type', formData.budget?.type);
       }
+      setRequestLoaded(true);
     }
   }, [request, setValue, session, router, sessionStatus, requestLoaded]);
 

--- a/src/components/layout/playground/submitRequestForm.tsx
+++ b/src/components/layout/playground/submitRequestForm.tsx
@@ -98,6 +98,10 @@ const SubmitRequestForm: React.FC<SubmitRequestFormParam> = ({ requestId }) => {
     { id: requestId, extended: true },
     {
       enabled: !!requestId,
+      cacheTime: 0,
+      onSuccess: () => {
+        setRequestLoaded(true);
+      },
     }
   );
 
@@ -153,7 +157,6 @@ const SubmitRequestForm: React.FC<SubmitRequestFormParam> = ({ requestId }) => {
         setIsFree(false);
         setValue('budget.type', formData.budget?.type);
       }
-      setRequestLoaded(true);
     }
   }, [request, setValue, session, router, sessionStatus, requestLoaded]);
 

--- a/src/components/layout/playground/submitRequestForm.tsx
+++ b/src/components/layout/playground/submitRequestForm.tsx
@@ -63,6 +63,7 @@ interface SubmitRequestFormParam {
 
 const SubmitRequestForm: React.FC<SubmitRequestFormParam> = ({ requestId }) => {
   const { data: session, status: sessionStatus } = useSession();
+  const utils = trpc.useContext();
 
   const { budget: storedBudget, ...storedForm } =
     usePlaygroundSubmitRequestStore((state) => state.form);
@@ -286,10 +287,10 @@ const SubmitRequestForm: React.FC<SubmitRequestFormParam> = ({ requestId }) => {
           keepValues: true,
         });
       }
-
       await mutate(values);
+      await utils.playground.getRequest.invalidate({ id: requestId });
     },
-    [mutate, reset, sessionStatus]
+    [mutate, reset, sessionStatus, requestId, utils.playground.getRequest]
   );
 
   useOnce(


### PR DESCRIPTION
[Trello Card](https://trello.com/c/LjKuvjEI/17-fix-old-value-caching-for-playground-submit-form)

> When editing a request the values will change and it will update in the frontend, but when clicking on edit again the old values load again in the input fields. After going back to the overview page and clicking once more on edit requests the new values appear.

- Sets `useQuery()` `.cacheTime` to 0 to stop outdated data being stored
- Changed `requestLoaded` to only set to loaded once the correct data has been queried

The database is always correctly updated immediately and I couldn't find any stale data stored in the browser.

Via a console log in the `onSuccess` method, I confirmed that the `getRequest.useQuery()` is retrieving the correct data. However, `request` is somehow getting stale data before that which means the form was being populated and not updated again due to the `setRequestLoaded(true)`.

By having `setRequestLoaded(true)` only run once the correct data is queried, I am hopefully ensuring the fields are able to be populated with correct data and then never again.

What confuses me is that I don't think the 'cacheTime' change always fixes the issue in itself, so I still don't quite understand where the cached data is still coming from. So if someone could let me know what I'm missing that would be great.

Otherwise, an alternative could be to move the field population code out from its `useEffect()` and into a function that is executed via `onSuccess` to guarantee it only runs with updated data.