### PR TITLE
Fix/translation setup

### DIFF
--- a/src/components/layout/grants/grantsApplication.tsx
+++ b/src/components/layout/grants/grantsApplication.tsx
@@ -181,15 +181,15 @@ const GrantsApplication: React.FC = () => {
                   error={errors.gender?.message}
                   options={[
                     intl.formatMessage({
-                      id: 'page.grants.section.application.form.a.input.applicant-gender.option[0]',
+                      id: 'page.grants.section.application.form.a.input.applicant-gender.option.0',
                       defaultMessage: 'male',
                     }),
                     intl.formatMessage({
-                      id: 'page.grants.section.application.form.a.input.applicant-gender.option[1]',
+                      id: 'page.grants.section.application.form.a.input.applicant-gender.option.1',
                       defaultMessage: 'female',
                     }),
                     intl.formatMessage({
-                      id: 'page.grants.section.application.form.a.input.applicant-gender.option[2]',
+                      id: 'page.grants.section.application.form.a.input.applicant-gender.option.2',
                       defaultMessage: 'other',
                     }),
                   ].map((option) => ({
@@ -378,7 +378,7 @@ const GrantsApplication: React.FC = () => {
         >
           <FormattedMessage
             id="page.grants.section.application.form.c.intro"
-            defaultMessage="<div> Your project's budget is a very important part of your application. Our team often uses this information to support their final decisions. Keep in mind that the budget items you list are ones that will serve to complete your proposed project, so be very specific in how the requested funding will be used. </div> <div> Please note, all information in this section should be given in <b>US Dollars</b> (US$). </div>"
+            defaultMessage="<div>Your project's budget is a very important part of your application. Our team often uses this information to support their final decisions. Keep in mind that the budget items you list are ones that will serve to complete your proposed project, so be very specific in how the requested funding will be used.</div> <div>Please note, all information in this section should be given in <b>US Dollars</b> (US$).</div>"
             values={{
               div: (chunks) => <div>{chunks}</div>,
               b: (chunks) => <b>{chunks}</b>,
@@ -455,7 +455,7 @@ const GrantsApplication: React.FC = () => {
             <div className="font-normal">
               <FormattedMessage
                 id="page.grants.section.application.form.c.input.funds-usage.text"
-                defaultMessage="Please list each budget item and the associated cost. The total should equal the total funding you are requesting from TPP. Example: <ul> <li>1 1lb bag of corn - $5</li> <li>3 Garden Shovels - $35</li> </ul>"
+                defaultMessage="Please list each budget item and the associated cost. The total should equal the total funding you are requesting from <no-localization>TPP</no-localization>. Example: <ul> <li>1 1lb bag of corn - $5</li> <li>3 Garden Shovels - $35</li> </ul>"
                 values={{
                   ul: (chunks) => (
                     <ul className="list-disc list-inside">{chunks}</ul>
@@ -476,7 +476,7 @@ const GrantsApplication: React.FC = () => {
               <>
                 <FormattedMessage
                   id="page.grants.section.application.form.c.input.can-accept-funding.text"
-                  defaultMessage="I confirm that I have a bank or PayPal account that is in my name or my organization's name and that can receive grant payments in US Dollars. I confirm my understanding that - with the exception of my fiscal sponsor, if applicable - TPP is unable to make grant payments to any other person or entity on my behalf. I understand that if TPP reviews my proposal and decides to make an offer of funding, that offer is conditional on the ability to accept funds to an account in my name or in my organization's name."
+                  defaultMessage="I confirm that I have a bank or <no-localization>PayPal</no-localization> account that is in my name or my organization's name and that can receive grant payments in US Dollars. I confirm my understanding that - with the exception of my fiscal sponsor, if applicable - <no-localization>TPP</no-localization> is unable to make grant payments to any other person or entity on my behalf. I understand that if <no-localization>TPP</no-localization> reviews my proposal and decides to make an offer of funding, that offer is conditional on the ability to accept funds to an account in my name or in my organization's name."
                 />
               </>
             }

--- a/src/components/layout/grants/grantsPerks.tsx
+++ b/src/components/layout/grants/grantsPerks.tsx
@@ -23,13 +23,13 @@ const PERKS: PerkProps[] = [
     title: (
       <FormattedMessage
         id="page.grants.section.perks.squarespace.heading"
-        defaultMessage="Squarespace Website Subscription"
+        defaultMessage="<no-localization>Squarespace</no-localization> Website Subscription"
       />
     ),
     children: (
       <>
         <FormattedMessage
-          id="page.grants.section.perks.squarespace.content"
+          id="page.grants.section.perks.squarespace.paragraph"
           defaultMessage="<div>Valued at $200, we cover the subscription cost for the first year.</div> <div>You own it, and we help you design and maintain it.</div> <div>Easy to update with little to no experience.</div>"
           values={{
             div: (chunks) => <div>{chunks}</div>,
@@ -49,7 +49,7 @@ const PERKS: PerkProps[] = [
     children: (
       <>
         <FormattedMessage
-          id="page.grants.section.perks.design-creation.content"
+          id="page.grants.section.perks.design-creation.paragraph"
           defaultMessage="Depending on your needs, we design (or redesign) the branding and logo for your organization or project. We also provide digital assets, such as banners, icons, and any custom elements, for social media and your website."
         />
       </>
@@ -66,7 +66,7 @@ const PERKS: PerkProps[] = [
     children: (
       <>
         <FormattedMessage
-          id="page.grants.section.perks.content-dev.content"
+          id="page.grants.section.perks.content-dev.paragraph"
           defaultMessage="We help craft any public-facing messages, including website copy. We offer our writing and editing skills at any stage of the process: from initial brainstorming to reviewing copy that helps promote your work."
         />
       </>
@@ -83,8 +83,8 @@ const PERKS: PerkProps[] = [
     children: (
       <>
         <FormattedMessage
-          id="page.grants.section.perks.check-ins.content"
-          defaultMessage="A monthly 30-minute Zoom call to help advise you and your team. Topics include but are not limited to technology, marketing, strategy, and other aspects of your organization's growth and development."
+          id="page.grants.section.perks.check-ins.paragraph"
+          defaultMessage="A monthly 30-minute <no-localization>Zoom</no-localization> call to help advise you and your team. Topics include but are not limited to technology, marketing, strategy, and other aspects of your organization's growth and development."
         />
       </>
     ),

--- a/src/components/layout/grants/grantsPollinationProject.tsx
+++ b/src/components/layout/grants/grantsPollinationProject.tsx
@@ -15,7 +15,8 @@ const GrantsPollinationProject: React.FC = () => {
             src={PollinationProjectLogo}
             alt={intl.formatMessage({
               id: 'page.grants.section.pollination-project.image.alt-text',
-              defaultMessage: 'Logo of The Pollination Project',
+              defaultMessage:
+                'Logo of <no-localization>The Pollination Project</no-localization>',
             })}
             sizes="100vw"
           />
@@ -23,14 +24,14 @@ const GrantsPollinationProject: React.FC = () => {
         <div className="flex-1 py-8 px-3 md:px-10 bg-gray-background text-center md:text-left text-2xl">
           <p>
             <FormattedMessage
-              id="page.grants.section.pollination-project.content[0]"
-              defaultMessage="Our grants connection service is generously funded by The Pollination Project (TPP) and other private donors— please keep an eye out in your inbox, and don't forget to check spam!"
+              id="page.grants.section.pollination-project.paragraph.0"
+              defaultMessage="Our grants connection service is generously funded by <no-localization>The Pollination Project (TPP)</no-localization> and other private donors— please keep an eye out in your inbox, and don't forget to check spam!"
             />
           </p>
           <p className="mt-4">
             <FormattedMessage
-              id="page.grants.section.pollination-project.content[1]"
-              defaultMessage="If your primary focus does not address farmed animals, you may still be eligible for a grant directly from TPP. We encourage you to apply through their website."
+              id="page.grants.section.pollination-project.paragraph.1"
+              defaultMessage="If your primary focus does not address farmed animals, you may still be eligible for a grant directly from <no-localization>TPP</no-localization>. We encourage you to apply through their website."
             />
           </p>
           <LightButton
@@ -39,7 +40,7 @@ const GrantsPollinationProject: React.FC = () => {
           >
             <FormattedMessage
               id="page.grants.section.pollination-project.button"
-              defaultMessage="ThePollinationProject.org"
+              defaultMessage="<no-localization>ThePollinationProject.org</no-localization>"
             />
           </LightButton>
         </div>

--- a/src/components/layout/grants/grantsQualifications.tsx
+++ b/src/components/layout/grants/grantsQualifications.tsx
@@ -53,7 +53,7 @@ const GrantsQualifications: React.FC = () => {
         </h3>
         <GrantsQualificationsStep step="1">
           <FormattedMessage
-            id="page.grants.section.qualifications.step[0].content"
+            id="page.grants.section.qualifications.steps.paragraph.0"
             defaultMessage="<b> Your primary goal </b> should focus on reducing farmed animal suffering. Factory farming causes over 100 billion animals to suffer deprivation, fear, and pain every year."
             values={{
               b: (chunks) => <b>{chunks}</b>,
@@ -62,7 +62,7 @@ const GrantsQualifications: React.FC = () => {
         </GrantsQualificationsStep>
         <GrantsQualificationsStep step="2">
           <FormattedMessage
-            id="page.grants.section.qualifications.step[1].content"
+            id="page.grants.section.qualifications.steps.paragraph.1"
             defaultMessage="<b> You must have </b> prior activism experience, whether in animal rights or other social movements. We're looking for people who have worked on and contributed to grassroots campaigns and/or projects, in a paid or volunteer capacity."
             values={{
               b: (chunks) => <b>{chunks}</b>,
@@ -72,7 +72,7 @@ const GrantsQualifications: React.FC = () => {
         <p className="mt-12 text-2xl font-thin">
           <i>
             <FormattedMessage
-              id="page.grants.section.qualifications.cta[0].content"
+              id="page.grants.section.qualifications.cta.paragraph.0"
               defaultMessage="<b>Don't meet the qualifications above?</b> You may still be eligible for funding! Apply and we'll forward your application to other potential funders."
               values={{
                 b: (chunks) => <b>{chunks}</b>,
@@ -83,7 +83,7 @@ const GrantsQualifications: React.FC = () => {
         <p className="mt-10 mb-4 text-2xl">
           <b>
             <FormattedMessage
-              id="page.grants.section.qualifications.cta[1].content"
+              id="page.grants.section.qualifications.cta.paragraph.1"
               defaultMessage="If you meet the qualifications, fill out the application form below."
             />
           </b>

--- a/src/components/layout/work/grantProgram.tsx
+++ b/src/components/layout/work/grantProgram.tsx
@@ -44,7 +44,7 @@ const GrantProgram: React.FC = () => {
                     <p className="text-xl text-left">
                       <FormattedMessage
                         id="page.our-work.section.grant-program.section-header.content"
-                        defaultMessage="Last year, we announced a partnership with The Pollination Project to offer seed funding to individuals and grassroots organizations. Here’s what we’ve accomplished to date."
+                        defaultMessage="Last year, we announced a partnership with <no-localization>The Pollination Project</no-localization> to offer seed funding to individuals and grassroots organizations. Here’s what we’ve accomplished to date."
                       />
                     </p>
                     <DarkButton href="/grants" className="w-full lg:w-1/2">

--- a/src/components/layout/work/kindWords.tsx
+++ b/src/components/layout/work/kindWords.tsx
@@ -45,39 +45,65 @@ const Quote = ({ author, company, children, color }: QuoteProps) => {
 
 const getQuotes: (intl: IntlShape) => QuoteProps[] = (intl) => [
   {
-    company: 'Mercy for Animals',
-    author: 'Courtney Dillard',
+    company: intl.formatMessage({
+      id: 'page.our-work.section.kind-words[0].company',
+      defaultMessage: '<no-localization>Mercy for Animals</no-localization>',
+    }),
+    author: intl.formatMessage({
+      id: 'page.our-work.section.kind-words[0].author',
+      defaultMessage: '<no-localization>Courtney Dillard</no-localization>',
+    }),
     children: intl.formatMessage({
       id: 'page.our-work.section.kind-words[0].content',
       defaultMessage:
-        'What impresses me most about the Vegan Hacktivists is their high level of critical thinking in terms of ideation and their consistent follow through. This has resulted in several high level deliverables I have been able to use and highly recommended to others.',
+        'What impresses me most about the <no-localization>Vegan Hacktivists</no-localization> is their high level of critical thinking in terms of ideation and their consistent follow through. This has resulted in several high level deliverables I have been able to use and highly recommended to others.',
     }),
   },
   {
-    company: 'Ben Williamson',
-    author: 'Compassion In World Farming',
+    company: intl.formatMessage({
+      id: 'page.our-work.section.kind-words[1].company',
+      defaultMessage:
+        '<no-localization>Compassion In World Farming</no-localization>',
+    }),
+    author: intl.formatMessage({
+      id: 'page.our-work.section.kind-words[1].author',
+      defaultMessage: '<no-localization>Ben Williamson</no-localization>',
+    }),
     children: intl.formatMessage({
       id: 'page.our-work.section.kind-words[1].content',
       defaultMessage:
-        'I’m really excited by the potential Vegan Hacktivists have for the animal protection movement. Progress is full of tipping points, and I’m sure at least one of these lives within a technological solution offered by this skilled community of advocates.',
+        'I’m really excited by the potential <no-localization>Vegan Hacktivists</no-localization> have for the animal protection movement. Progress is full of tipping points, and I’m sure at least one of these lives within a technological solution offered by this skilled community of advocates.',
     }),
   },
   {
-    company: 'The Pollination Project',
-    author: 'AJ Dahiya',
+    company: intl.formatMessage({
+      id: 'page.our-work.section.kind-words[2].company',
+      defaultMessage:
+        '<no-localization>The Pollination Project</no-localization>',
+    }),
+    author: intl.formatMessage({
+      id: 'page.our-work.section.kind-words[2].author',
+      defaultMessage: '<no-localization>AJ Dahiya</no-localization>',
+    }),
     children: intl.formatMessage({
       id: 'page.our-work.section.kind-words[2].content',
       defaultMessage:
-        'Vegan Hacktivists is an innovative organization leveraging technology to make a large-scale impact for the rights and dignity of animals. They have gone above and beyond in supporting our organization with their expertise. Their work is extremely needed and on the cutting edge for the time we live in.',
+        '<no-localization>Vegan Hacktivists</no-localization> is an innovative organization leveraging technology to make a large-scale impact for the rights and dignity of animals. They have gone above and beyond in supporting our organization with their expertise. Their work is extremely needed and on the cutting edge for the time we live in.',
     }),
   },
   {
-    company: 'Faunalytics',
-    author: 'Brooke Haggerty',
+    company: intl.formatMessage({
+      id: 'page.our-work.section.kind-words[3].company',
+      defaultMessage: '<no-localization>Faunalytics</no-localization>',
+    }),
+    author: intl.formatMessage({
+      id: 'page.our-work.section.kind-words[3].author',
+      defaultMessage: '<no-localization>Brooke Haggerty</no-localization>',
+    }),
     children: intl.formatMessage({
       id: 'page.our-work.section.kind-words[3].content',
       defaultMessage:
-        'Vegan Hacktivists is a hidden gem in the animal protection movement. They are capacity builders, dedicated to supporting other animal advocates. We’ve been fortunate enough to receive their help with several behind the scenes projects, and I’m constantly impressed with their passion and professionalism.',
+        '<no-localization>Vegan Hacktivists</no-localization> is a hidden gem in the animal protection movement. They are capacity builders, dedicated to supporting other animal advocates. We’ve been fortunate enough to receive their help with several behind the scenes projects, and I’m constantly impressed with their passion and professionalism.',
     }),
   },
 ];

--- a/src/components/layout/work/ourCommunities.tsx
+++ b/src/components/layout/work/ourCommunities.tsx
@@ -65,7 +65,7 @@ const OurCommunities: React.FC = () => {
                 <a href={redditLink} target="_blank" rel="noreferrer">
                   <FormattedMessage
                     id="page.our-work.section.our-communities.cta.reddit"
-                    defaultMessage="Vegans of Reddit"
+                    defaultMessage="Vegans of <no-localization>Reddit</no-localization>"
                   />
                 </a>
               </div>
@@ -79,7 +79,10 @@ const OurCommunities: React.FC = () => {
               </div>
               <div className="font-bold">
                 <a href={discordLink} target="_blank" rel="noreferrer">
-                  Animal Rights Advocates
+                  <FormattedMessage
+                    id="page.our-work.section.our-communities.cta.animal-rights-advocates"
+                    defaultMessage="<no-localization>Animal Rights Advocates</no-localization>"
+                  />
                 </a>
               </div>
               <div>{araMembers}</div>

--- a/src/components/layout/work/playground.tsx
+++ b/src/components/layout/work/playground.tsx
@@ -44,7 +44,7 @@ const Playground: React.FC = () => {
           <div className="text-lg space-y-3 mx-auto">
             <FormattedMessage
               id="page.our-work.section.playground.introduction"
-              defaultMessage="<p>Playground was our response to meet the overwhelming demand of tech and design support in our movement, while staying sustainable as an organization with limited capacity. We prioritized automating the process of connecting organizations with technical, design, and other support needs with skilled volunteers.</p> <p>Beyond design and software development, these volunteers are professionals with a wide array of skills and backgrounds in data science, videography, marketing, security, research, and much more.</p>"
+              defaultMessage="<p><no-localization>Playground</no-localization> was our response to meet the overwhelming demand of tech and design support in our movement, while staying sustainable as an organization with limited capacity. We prioritized automating the process of connecting organizations with technical, design, and other support needs with skilled volunteers.</p> <p>Beyond design and software development, these volunteers are professionals with a wide array of skills and backgrounds in data science, videography, marketing, security, research, and much more.</p>"
               values={{
                 p: (chunk) => <p>{chunk}</p>,
               }}

--- a/src/components/layout/work/sharingKnowledgeAndSupport.tsx
+++ b/src/components/layout/work/sharingKnowledgeAndSupport.tsx
@@ -1,4 +1,4 @@
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import family from '../../../../public/images/yearInReview/2022/vh-family.jpg';
 import malina from '../../../../public/images/yearInReview/2022/malina-tran-at-care.jpg';
@@ -25,6 +25,7 @@ const BOTTOM_DECORATION_SQUARES = [
 ];
 
 const SharingKnowledgeAndSupport: React.FC = () => {
+  const intl = useIntl();
   return (
     <>
       <SquareField
@@ -44,7 +45,7 @@ const SharingKnowledgeAndSupport: React.FC = () => {
               <p className="text-xl max-w-prose">
                 <FormattedMessage
                   id="page.our-work.section.sharing-knowledge-and-support.section-header.content"
-                  defaultMessage="We're often speaking at animal protection and EA related conferences every year and around the world! Be sure to look out for our booth or speakers, we'd love to meet you and see where we might be able to support your work. Follow us on <link>Instagram</link> to see where we'll be next!"
+                  defaultMessage="We're often speaking at animal protection and <no-localization>EA</no-localization> related conferences every year and around the world! Be sure to look out for our booth or speakers, we'd love to meet you and see where we might be able to support your work. Follow us on <no-localization><link>Instagram</link></no-localization> to see where we'll be next!"
                   values={{
                     link: (chunk) => (
                       <CustomLink href="https://instagram.com/veganhacktivists">
@@ -64,16 +65,30 @@ const SharingKnowledgeAndSupport: React.FC = () => {
               <ImageWithCaption
                 bgColor="yellow"
                 image={malina}
-                caption={'Malina Tran at CARE Conference'}
-                subcaption={'Data & Tech in Animal Rights Activism'}
+                caption={intl.formatMessage({
+                  id: 'page.our-work.section.sharing-knowledge-and-support.conferences.1.caption',
+                  defaultMessage:
+                    '<no-localization>Malina Tran</no-localization> at <no-localization>CARE</no-localization> Conference',
+                })}
+                subcaption={intl.formatMessage({
+                  id: 'page.our-work.section.sharing-knowledge-and-support.conferences.1.subcaption',
+                  defaultMessage: 'Data & Tech in Animal Rights Activism',
+                })}
               />
             </div>
             <div className="flex">
               <ImageWithCaption
                 bgColor="green"
                 image={james}
-                caption={'James Morgan at AVA Summit'}
-                subcaption={'Tech Innovation in Animal Protection'}
+                caption={intl.formatMessage({
+                  id: 'page.our-work.section.sharing-knowledge-and-support.conferences.2.caption',
+                  defaultMessage:
+                    '<no-localization>James Morgan</no-localization> at <no-localization>AVA Summit</no-localization>',
+                })}
+                subcaption={intl.formatMessage({
+                  id: 'page.our-work.section.sharing-knowledge-and-support.conferences.2.subcaption',
+                  defaultMessage: 'Tech Innovation in Animal Protection',
+                })}
               />
             </div>
           </div>

--- a/src/components/layout/work/stateOfData.tsx
+++ b/src/components/layout/work/stateOfData.tsx
@@ -48,7 +48,7 @@ const StateOfData: React.FC = () => {
                 <p className="text-xl">
                   <FormattedMessage
                     id="page.our-work.section.state-of-data.content"
-                    defaultMessage="We launched the first-of-its-kind study to understand how our movement leverages technology. With guidance from Faunalytics and research conducted by Animetrics, our 50-page report explores challenges and opportunities across various topics such as employment and workforce, websites and applications, social media, data collection and analysis, and security. Our recommendations are meant to provide actionable solutions for stakeholders and community members on how we can become a more technological, data-driven movement."
+                    defaultMessage="We launched the first-of-its-kind study to understand how our movement leverages technology. With guidance from <no-localization>Faunalytics</no-localization> and research conducted by <no-localization>Animetrics</no-localization>, our 50-page report explores challenges and opportunities across various topics such as employment and workforce, websites and applications, social media, data collection and analysis, and security. Our recommendations are meant to provide actionable solutions for stakeholders and community members on how we can become a more technological, data-driven movement."
                   />
                 </p>
 

--- a/src/components/layout/yearInReview/organizations.tsx
+++ b/src/components/layout/yearInReview/organizations.tsx
@@ -19,53 +19,54 @@ export const Organizations: React.FC = () => {
     savemovement: {
       title: intl.formatMessage({
         id: 'page.year-in-review.2020.section.working-with-organizations.animal-save-movement.heading',
-        defaultMessage: 'Animal Save Movement',
+        defaultMessage:
+          '<no-localization>Animal Save Movement</no-localization>',
       }),
       url: 'thesavemovement.org',
       image: saveMovementImage,
       content: intl.formatMessage({
-        id: 'page.year-in-review.2020.section.working-with-organizations.animal-save-movement.content',
+        id: 'page.year-in-review.2020.section.working-with-organizations.animal-save-movement.paragraph',
         defaultMessage:
-          "We were able to work with Animal Save and help them with their new website. We also helped with their Ad campaign and managed those for a few months to help promote more of Save's work and newsletter. If you haven't heard of Save, their mission is to hold vigils at every slaughterhouse and to bear witness to every exploited animal. They also run the Climate and Health Save Movement, which promote reversing catastrophic climate change and making plant-based diets accessible. It was an absolute joy to meet and work with their team of passionate activists!",
+          "We were able to work with <no-localization>Animal Save</no-localization> and help them with their new website. We also helped with their Ad campaign and managed those for a few months to help promote more of <no-localization>Save's</no-localization> work and newsletter. If you haven't heard of <no-localization>Save</no-localization>, their mission is to hold vigils at every slaughterhouse and to bear witness to every exploited animal. They also run the Climate and Health Save Movement, which promote reversing catastrophic climate change and making plant-based diets accessible. It was an absolute joy to meet and work with their team of passionate activists!",
       }),
     },
     animalrebellion: {
       title: intl.formatMessage({
         id: 'page.year-in-review.2020.section.working-with-organizations.animal-rebellion.heading',
-        defaultMessage: 'Animal Rebellion',
+        defaultMessage: '<no-localization>Animal Rebellion</no-localization>',
       }),
       url: 'animalrebellion.org',
       image: animalRebellionImage,
       content: intl.formatMessage({
-        id: 'page.year-in-review.2020.section.working-with-organizations.animal-rebellion.content',
+        id: 'page.year-in-review.2020.section.working-with-organizations.animal-rebellion.paragraph',
         defaultMessage:
-          'We partnered with Animal Rebellion this year to help build their new website, which we dedicated an entire team for that took about 6 months of work. Their tech team were fantastic to work with, they were very knowledgeable and we felt like we were working with a team of professional during each encounter during our work. Animal Rebellion is a mass movement that uses nonviolent civil resistance to bring about a transition to a just and sustainable plant-based food system as an attempt to halt massive extinction, alleviate the worst effects of climate breakdown, and ensure justice for animals.',
+          'We partnered with <no-localization>Animal Rebellion</no-localization> this year to help build their new website, which we dedicated an entire team for that took about 6 months of work. Their tech team were fantastic to work with, they were very knowledgeable and we felt like we were working with a team of professional during each encounter during our work. <no-localization>Animal Rebellion</no-localization> is a mass movement that uses nonviolent civil resistance to bring about a transition to a just and sustainable plant-based food system as an attempt to halt massive extinction, alleviate the worst effects of climate breakdown, and ensure justice for animals.',
       }),
     },
     lebanesevegans: {
       title: intl.formatMessage({
         id: 'page.year-in-review.2020.section.working-with-organizations.lebanese-vegans.heading',
-        defaultMessage: 'Lebanese Vegans',
+        defaultMessage: '<no-localization>Lebanese Vegans</no-localization>',
       }),
       url: 'lebanesevegans.org',
       image: lebaneseVegansImage,
       content: intl.formatMessage({
-        id: 'page.year-in-review.2020.section.working-with-organizations.lebanese-vegans.content',
+        id: 'page.year-in-review.2020.section.working-with-organizations.lebanese-vegans.paragraph',
         defaultMessage:
-          'The Lebanese Vegans social hub is the only animal rights and vegan support center in Southwest Asia and North Africa offering free monthly workshops and lectures about veganism, free weekly food distribution and monthly campaigns raising awareness about animal rights. We were lucky enough to work with them to help them both launch their new website and also re-branding with a new logo. We had a great time working through our advisor, Seb Alex, who organizes the work behind Lebanese Vegans.',
+          'The <no-localization>Lebanese Vegans</no-localization> social hub is the only animal rights and vegan support center in Southwest Asia and North Africa offering free monthly workshops and lectures about veganism, free weekly food distribution and monthly campaigns raising awareness about animal rights. We were lucky enough to work with them to help them both launch their new website and also re-branding with a new logo. We had a great time working through our advisor, <no-localization>Seb Alex</no-localization>, who organizes the work behind <no-localization>Lebanese Vegans</no-localization>.',
       }),
     },
     theexcelsior4: {
       title: intl.formatMessage({
         id: 'page.year-in-review.2020.section.working-with-organizations.excelsior.heading',
-        defaultMessage: 'The Excelsior 4',
+        defaultMessage: '<no-localization>The Excelsior 4</no-localization>',
       }),
       url: 'excelsior4.org',
       image: theExcelsior4Image,
       content: intl.formatMessage({
-        id: 'page.year-in-review.2020.section.working-with-organizations.excelsior.content',
+        id: 'page.year-in-review.2020.section.working-with-organizations.excelsior.paragraph',
         defaultMessage:
-          "The Excelsior 4 are four activists are facing charges, with 21 counts in total after exposing criminal animal cruelty at Excelsior Hog Farm. We worked with them to get a new site launched that would allow them to fundraise their legal defense as fast as possible. We really think that the work they did and what they exposed is extremely important and we're so happy to have had the chance to support and help them get up and running. Please do check them out and support if you can!",
+          "The <no-localization>Excelsior 4</no-localization> are four activists are facing charges, with 21 counts in total after exposing criminal animal cruelty at <no-localization>Excelsior</no-localization> Hog Farm. We worked with them to get a new site launched that would allow them to fundraise their legal defense as fast as possible. We really think that the work they did and what they exposed is extremely important and we're so happy to have had the chance to support and help them get up and running. Please do check them out and support if you can!",
       }),
     },
   };

--- a/src/pages/about/our-mission.tsx
+++ b/src/pages/about/our-mission.tsx
@@ -48,57 +48,57 @@ const OurMission: PageWithLayout = () => {
         <div>
           <SubSection
             header={intl.formatMessage({
-              id: 'page.about.section.our-mission.subsection-1.heading',
+              id: 'page.about.section.our-mission.subsection-0.heading',
               defaultMessage: '1. We need more data in our movement.',
             })}
           >
             <FormattedMessage
-              id="page.about.section.our-mission.subsection-1.content"
+              id="page.about.section.our-mission.subsection-0.paragraph"
               defaultMessage="To determine effectiveness in projects, campaigns, and our work as a whole, meaningful data needs to be tracked and collected. We strongly believe that a data-driven movement will accelerate and elevate our work, which is why we prioritize identifying, gathering, and analyzing data, as well as making it accessible to others."
             />
           </SubSection>
           <SubSection
             header={intl.formatMessage({
-              id: 'page.about.section.our-mission.subsection-2.heading',
+              id: 'page.about.section.our-mission.subsection-1.heading',
               defaultMessage: '2. We need more competition, too.',
             })}
           >
             <FormattedMessage
-              id="page.about.section.our-mission.subsection-2.content"
+              id="page.about.section.our-mission.subsection-1.paragraph"
               defaultMessage="We strongly believe competition is not only healthy but vital in improving our movement's effectiveness. Competition applies healthy pressure on organizations and projects to keep improving and iterating – and this gives us more information on what works."
             />
           </SubSection>
           <SubSection
             header={intl.formatMessage({
-              id: 'page.about.section.our-mission.subsection-3.heading',
+              id: 'page.about.section.our-mission.subsection-2.heading',
               defaultMessage: '3. We need to be more innovative.',
             })}
           >
             <FormattedMessage
-              id="page.about.section.our-mission.subsection-3.content"
+              id="page.about.section.our-mission.subsection-2.paragraph"
               defaultMessage="We believe the movement has the potential to be more innovative in its approaches. We promote outside-the-box thinking and make innovation a core consideration of every part of our work and our processes."
             />
           </SubSection>
           <SubSection
             header={intl.formatMessage({
-              id: 'page.about.section.our-mission.subsection-4.heading',
+              id: 'page.about.section.our-mission.subsection-3.heading',
               defaultMessage: '4. And we need to start collaborating.',
             })}
           >
             <FormattedMessage
-              id="page.about.section.our-mission.subsection-4.content"
+              id="page.about.section.our-mission.subsection-3.paragraph"
               defaultMessage="We aim to help organizations and individuals connect and collaborate in more meaningful ways. We need to leverage our knowledge and network with each other to support our shared goals, whether that means sharing research or data, resources, or generally supporting each other overcome organizational challenges."
             />
           </SubSection>
           <SubSection
             header={intl.formatMessage({
-              id: 'page.about.section.our-mission.subsection-5.heading',
+              id: 'page.about.section.our-mission.subsection-4.heading',
               defaultMessage:
                 '5. Finally, we need more vegans to become active.',
             })}
           >
             <FormattedMessage
-              id="page.about.section.our-mission.subsection-5.content"
+              id="page.about.section.our-mission.subsection-4.paragraph"
               defaultMessage="Only a tiny percentage of the world is vegan, and a fraction within are active. Many organizations encourage non-vegans to adopt veganism through health, environmental, or ethical reasons. We believe that we can also be effective by creating tools to help, inspire, and motivate more vegans to become advocates for the animals."
             />
           </SubSection>

--- a/src/pages/about/our-story.tsx
+++ b/src/pages/about/our-story.tsx
@@ -25,12 +25,12 @@ const OurStory: PageWithLayout = () => {
       />
       <FirstSubSection
         header={intl.formatMessage({
-          id: 'page.about.section.our-story.section-header.heading',
+          id: 'page.about.section.our-story.intro.heading',
           defaultMessage: 'Our story',
         })}
       >
         <FormattedMessage
-          id="page.about.section.our-story.section-header.content"
+          id="page.about.section.our-story.intro.paragraph"
           defaultMessage="In 2019, we launched our first project with a few volunteers who were passionate about activism. We’ve since grown into a community of highly-skilled and professional software engineers, designers, data scientists, and content creators supporting the movement. We started with the hopes of catalyzing people to action and inspiring them to become advocates for animals — and we are committed to this founding principle. Our digital skills fuel our activism."
         />
       </FirstSubSection>
@@ -41,20 +41,20 @@ const OurStory: PageWithLayout = () => {
             width={pixelPig.width / 3}
             height={pixelPig.height / 3}
             alt={intl.formatMessage({
-              id: 'page.about.section.our-story.section-header.image.alt-text',
+              id: 'page.about.section.our-story.image.alt-text',
               defaultMessage: 'Our story',
             })}
           />
         </div>
         <SubSection>
           <FormattedMessage
-            id="page.about.section.our-story.subsection-1.content"
-            defaultMessage="We are the Vegan Hacktivists. Our skill sets — whether it’s writing code, creating a brand identity, or analyzing data — are as diverse as the areas where we come from and where we live. We collaborate with each other to build projects that are data-driven, experimental, and effective. Our core team consists of director and senior-level team members who have experience and expertise in engineering, architecture, design, data, operations, and communications. Our volunteer base consists of teams managed by leads; each team has ownership of a project in which they are actively building and maintaining."
+            id="page.about.section.our-story.paragraph.0"
+            defaultMessage="We are the <no-localization>Vegan Hacktivists</no-localization>. Our skill sets — whether it’s writing code, creating a brand identity, or analyzing data — are as diverse as the areas where we come from and where we live. We collaborate with each other to build projects that are data-driven, experimental, and effective. Our core team consists of director and senior-level team members who have experience and expertise in engineering, architecture, design, data, operations, and communications. Our volunteer base consists of teams managed by leads; each team has ownership of a project in which they are actively building and maintaining."
           />
         </SubSection>
         <SubSection>
           <FormattedMessage
-            id="page.about.section.our-story.subsection-2.content"
+            id="page.about.section.our-story.paragraph.1"
             defaultMessage="Our organization takes a community-first approach. Given that our work requires patience and commitment, we energize our volunteers by creating a supportive environment that enables them to be engaged, effective, and impactful. As a distributed organization, we want to build a sense of community aligned by values and connected through meaningful and playful interactions. Each team is represented with a <link>fruit or vegetable</link> (taking plant-based to another level), and we balance our work with games, get-togethers, and community calls. Our volunteers are, after all, at the heart of our organization."
             values={{
               link: (chunks) => (
@@ -67,13 +67,13 @@ const OurStory: PageWithLayout = () => {
         </SubSection>
         <SubSection>
           <FormattedMessage
-            id="page.about.section.our-story.subsection-3.content"
+            id="page.about.section.our-story.paragraph.2"
             defaultMessage="Over the years, our organization has changed with the needs of our movement. While we now primarily focus on providing capacity-building services, we continue to build technology that we believe to be innovative and highly needed in the movement. Now, we work extensively with advocates, organizations, and those working at the frontlines to help improve their day-to-day operations, brand and identity, and technology. In doing so, we are helping to amplify their message and elevate their work to a wider audience."
           />
         </SubSection>
         <SubSection>
           <FormattedMessage
-            id="page.about.section.our-story.subsection-4.content"
+            id="page.about.section.our-story.paragraph.3"
             defaultMessage="Through it all, our North Star remains the same: <no-localization>{break}</no-localization> we do it for the animals."
             values={{
               break: <br />,

--- a/src/pages/about/our-values.tsx
+++ b/src/pages/about/our-values.tsx
@@ -48,72 +48,72 @@ const OurValues: PageWithLayout = () => {
 
         <SubSection
           header={intl.formatMessage({
-            id: 'page.about.section.our-values.subsection-1.heading',
+            id: 'page.about.section.our-values.subsection-0.heading',
             defaultMessage: 'Animal Liberation',
           })}
         >
           <FormattedMessage
-            id="page.about.section.our-values.subsection-1.content"
+            id="page.about.section.our-values.subsection-0.paragraph"
             defaultMessage="We value and respect the lives of all animals and denounce all forms of violence and exploitation against them. We believe animals have the right to be free, and we fight for that with our (digital) activism."
           />
         </SubSection>
 
         <SubSection
           header={intl.formatMessage({
-            id: 'page.about.section.our-values.subsection-2.heading',
+            id: 'page.about.section.our-values.subsection-1.heading',
             defaultMessage: 'Non-violence',
           })}
         >
           <FormattedMessage
-            id="page.about.section.our-values.subsection-2.content"
+            id="page.about.section.our-values.subsection-1.paragraph"
             defaultMessage="We practice a love-based, community-first organizational approach. We exercise empathy, compassion, and non-violence. We encourage every member to communicate openly and kindly with each other."
           />
         </SubSection>
 
         <SubSection
           header={intl.formatMessage({
-            id: 'page.about.section.our-values.subsection-3.heading',
+            id: 'page.about.section.our-values.subsection-2.heading',
             defaultMessage: 'Safe Community',
           })}
         >
           <FormattedMessage
-            id="page.about.section.our-values.subsection-3.content"
+            id="page.about.section.our-values.subsection-2.paragraph"
             defaultMessage="We believe in building and fostering safe and inclusive communities regardless of race, gender, species, age, sexual orientation, or political affiliation. We strive to be diverse and representative of the communities we serve and work with."
           />
         </SubSection>
 
         <SubSection
           header={intl.formatMessage({
-            id: 'page.about.section.our-values.subsection-4.heading',
+            id: 'page.about.section.our-values.subsection-3.heading',
             defaultMessage: 'Farmed Animals',
           })}
         >
           <FormattedMessage
-            id="page.about.section.our-values.subsection-4.content"
+            id="page.about.section.our-values.subsection-3.paragraph"
             defaultMessage="We believe farmed animals are in most need of our support, which is why we focus primarily on farmed animal liberation as an organization."
           />
         </SubSection>
 
         <SubSection
           header={intl.formatMessage({
-            id: 'page.about.section.our-values.subsection-5.heading',
+            id: 'page.about.section.our-values.subsection-4.heading',
             defaultMessage: 'Open Feedback',
           })}
         >
           <FormattedMessage
-            id="page.about.section.our-values.subsection-5.content"
+            id="page.about.section.our-values.subsection-4.paragraph"
             defaultMessage="We value different viewpoints and constructive feedback from every person. We believe everyone has something of value to contribute to the discussion. We always listen first, then respond constructively."
           />
         </SubSection>
 
         <SubSection
           header={intl.formatMessage({
-            id: 'page.about.section.our-values.subsection-6.heading',
+            id: 'page.about.section.our-values.subsection-5.heading',
             defaultMessage: 'Anti-Oppression',
           })}
         >
           <FormattedMessage
-            id="page.about.section.our-values.subsection-6.content"
+            id="page.about.section.our-values.subsection-5.paragraph"
             defaultMessage="We do not support or enable the exploitation or oppression of any group. We believe that the oppression of humans and non-human animals are interlinked, and the work to eradicate all forms of oppression is necessary."
           />
         </SubSection>

--- a/src/pages/auth/signin.tsx
+++ b/src/pages/auth/signin.tsx
@@ -81,7 +81,7 @@ const SignIn: NextPage = () => {
       <div>
         <FormattedMessage
           id="page.sign-in.already-signed-in.content"
-          defaultMessage="You are already logged in. No callbackUrl provided. <button>Go to Playground</button>"
+          defaultMessage="You are already logged in. No <no-localization>callbackUrl</no-localization> provided. <button>Go to <no-localization>Playground</no-localization></button>"
           values={{
             button: (chunks) => (
               <NavButton href="/playground">{chunks}</NavButton>

--- a/src/pages/people/advisors.tsx
+++ b/src/pages/people/advisors.tsx
@@ -81,7 +81,7 @@ const Advisors: PageWithLayout<AdvisorsProps> = ({ advisors }) => {
         })}
       >
         <FormattedMessage
-          id="page.people.section.advisors.intro.text"
+          id="page.people.section.advisors.intro.paragraph"
           defaultMessage="We are incredibly thankful for our team of experienced advisors who provide guidance and direction to the organization, its strategy, and projects."
         />
       </FirstSubSection>
@@ -112,7 +112,7 @@ const Advisors: PageWithLayout<AdvisorsProps> = ({ advisors }) => {
           })}
         >
           <FormattedMessage
-            id="page.people.section.advisors.community.text"
+            id="page.people.section.advisors.community.paragraph"
             defaultMessage="We are more than a group of volunteers; we are a community tethered by shared values and invested in a vision of a better world for animals. We believe in a community-first approach: one that is supportive, growth-oriented, and accountable to each other. If this resonates with you, scroll down to learn more."
           />
         </FirstSubSection>

--- a/src/pages/people/partners.tsx
+++ b/src/pages/people/partners.tsx
@@ -110,7 +110,7 @@ const Partners: PageWithLayout<PartnerProps> = ({ partners }) => {
         })}
       >
         <FormattedMessage
-          id="page.people.section.partners.intro.text"
+          id="page.people.section.partners.intro.paragraph"
           defaultMessage="Here are partner organizations that we support and are supported by. Take a look to learn more about the amazing work they do!"
         />
       </FirstSubSection>
@@ -135,7 +135,7 @@ const Partners: PageWithLayout<PartnerProps> = ({ partners }) => {
           })}
         >
           <FormattedMessage
-            id="page.people.section.partners.community.text"
+            id="page.people.section.partners.community.paragraph"
             defaultMessage="We are more than a group of volunteers; we are a community tethered by shared values and invested in a vision of a better world for animals. We believe in a community-first approach: one that is supportive, growth-oriented, and accountable to each other. If this resonates with you, scroll down to learn more."
           />
         </FirstSubSection>

--- a/src/pages/people/team.tsx
+++ b/src/pages/people/team.tsx
@@ -232,7 +232,7 @@ const Team: PageWithLayout<TeamProps> = ({ teams, members }) => {
           })}
         >
           <FormattedMessage
-            id="page.people.section.team.community.text"
+            id="page.people.section.team.community.paragraph"
             defaultMessage="We are more than a group of volunteers; we are a community tethered by shared values and invested in a vision of a better world for animals. We believe in a community-first approach: one that is supportive, growth-oriented, and accountable to each other. If this resonates with you, scroll down to learn more."
           />
         </FirstSubSection>

--- a/src/pages/people/volunteers.tsx
+++ b/src/pages/people/volunteers.tsx
@@ -270,7 +270,7 @@ const Team: PageWithLayout<TeamProps> = ({ teams, teamMembers }) => {
         })}
       >
         <FormattedMessage
-          id="page.people.section.volunteers.intro.text"
+          id="page.people.section.volunteers.intro.paragraph"
           defaultMessage="Our volunteer community is at the heart of our organization, and enables us to build innovative projects and contribute to the movement in meaningful ways. <b>Click on an icon to meet the volunteers in each team!</b>"
           values={{
             b: (chunks) => <b>{chunks}</b>,
@@ -312,7 +312,7 @@ const Team: PageWithLayout<TeamProps> = ({ teams, teamMembers }) => {
           })}
         >
           <FormattedMessage
-            id="page.people.section.volunteers.community.text"
+            id="page.people.section.volunteers.community.paragraph"
             defaultMessage="We are more than a group of volunteers; we are a community tethered by shared values and invested in a vision of a better world for animals. We believe in a community-first approach: one that is supportive, growth-oriented, and accountable to each other. If this resonates with you, scroll down to learn more."
           />
         </FirstSubSection>

--- a/src/pages/year-in-review/2020.tsx
+++ b/src/pages/year-in-review/2020.tsx
@@ -151,24 +151,24 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
   const intl = useIntl();
   const PROJECTS_DESCRIPTION: Record<string, React.ReactNode> = {
     'Vegan Bootcamp': intl.formatMessage({
-      id: 'page.year-in-review.2020.section.highlighted-projects.vegan-bootcamp.content',
+      id: 'page.year-in-review.2020.section.highlighted-projects.vegan-bootcamp.paragraph',
       defaultMessage:
-        "Following the success of Vegan Bootcamp's launch in 2019 with over 5000+ signups, we decided to invest more time in improving it. We sent out a survey to all members and received a large amount of feedback helping us decide what new content and features were needed. Vegan Bootcamp now includes community forums, individual courses, tags, better rewards, advanced statistics for referrals, content search, a vegan dietitian support program, a mentorship support program, and it now comes translated in 10 different languages!",
+        "Following the success of <no-localization>Vegan Bootcamp's</no-localization> launch in 2019 with over 5000+ signups, we decided to invest more time in improving it. We sent out a survey to all members and received a large amount of feedback helping us decide what new content and features were needed. <no-localization>Vegan Bootcamp</no-localization> now includes community forums, individual courses, tags, better rewards, advanced statistics for referrals, content search, a vegan dietitian support program, a mentorship support program, and it now comes translated in 10 different languages!",
     }),
     'Animal Rights Map': intl.formatMessage({
-      id: 'page.year-in-review.2020.section.highlighted-projects.animal-rights-map.content',
+      id: 'page.year-in-review.2020.section.highlighted-projects.animal-rights-map.paragraph',
       defaultMessage:
-        "With over 2,500 groups, the Animal Rights Map is a globally updated map that helps vegans find local groups to get active with. Our map includes everyone from the largest organizations to the very small grassroots groups spread around the country. We worked with a few organizations to import new groups automatically, and we have a dedicated volunteer (that started this project) who meticulously updates the map almost every day. We've received a lot of great feedback for the map from vegans who were looking to get active - we plan on gathering more data soon and expanding the features of this map for 2021!",
+        "With over 2,500 groups, the <no-localization>Animal Rights Map</no-localization> is a globally updated map that helps vegans find local groups to get active with. Our map includes everyone from the largest organizations to the very small grassroots groups spread around the country. We worked with a few organizations to import new groups automatically, and we have a dedicated volunteer (that started this project) who meticulously updates the map almost every day. We've received a lot of great feedback for the map from vegans who were looking to get active - we plan on gathering more data soon and expanding the features of this map for 2021!",
     }),
     'Daily Nooch': intl.formatMessage({
-      id: 'page.year-in-review.2020.section.highlighted-projects.daily-nooch.content',
+      id: 'page.year-in-review.2020.section.highlighted-projects.daily-nooch.paragraph',
       defaultMessage:
-        "With this project we wanted to create something a little more fun and light-weight that vegans could enjoy consuming and sharing with the world. Daily Nooch is your one-stop source for daily vegan news, resources and inspiration. Designed to be your homepage, get the latest news, quotes, art, memes, facts, videos, and more updated every day at midnight. This project is very experimental and we don't know if vegans will use this consistently, but in the meantime the team had a lot of fun building it. If folks like it we have a bunch of fun ideas to explore that will add more interactivity to the project.",
+        "With this project we wanted to create something a little more fun and light-weight that vegans could enjoy consuming and sharing with the world. <no-localization>Daily Nooch</no-localization> is your one-stop source for daily vegan news, resources and inspiration. Designed to be your homepage, get the latest news, quotes, art, memes, facts, videos, and more updated every day at midnight. This project is very experimental and we don't know if vegans will use this consistently, but in the meantime the team had a lot of fun building it. If folks like it we have a bunch of fun ideas to explore that will add more interactivity to the project.",
     }),
     'My Daily Dozen': intl.formatMessage({
-      id: 'page.year-in-review.2020.section.highlighted-projects.my-daily-dozen.content',
+      id: 'page.year-in-review.2020.section.highlighted-projects.my-daily-dozen.paragraph',
       defaultMessage:
-        'Dr. Greger, founder of NutritionFacts.org, created an app called "Daily Dozen" that allows you to track your diet and make sure you get the best nutrition possible - and details the healthiest foods and how many servings of each we should try to check off every day. We wanted to expand on this concept and create a web-based version of his app with some additional features. Use My Daily Dozen to keep daily track of the foods recommended by Dr. Greger in his New York Times Bestselling book, How Not to Die. We hope that this project will give non-vegans the opportunity for an easier path to veganism by adopting a plant-based lifestyle.',
+        '<no-localization>Dr. Greger</no-localization>, founder of <no-localization>NutritionFacts.org</no-localization>, created an app called <no-localization>"Daily Dozen"</no-localization> that allows you to track your diet and make sure you get the best nutrition possible - and details the healthiest foods and how many servings of each we should try to check off every day. We wanted to expand on this concept and create a web-based version of his app with some additional features. Use My <no-localization>Daily Dozen</no-localization> to keep daily track of the foods recommended by <no-localization>Dr. Greger</no-localization> in his <no-localization>New York Times</no-localization> Bestselling book, <no-localization>How Not to Die</no-localization>. We hope that this project will give non-vegans the opportunity for an easier path to veganism by adopting a plant-based lifestyle.',
     }),
   };
   return (
@@ -215,34 +215,19 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
       <div className="h-12" />
       <HighlightBlock
         borderColor="magenta"
-        headerStart={intl.formatMessage({
-          id: 'page.year-in-review.2020.section.we-grew.launched.heading.start',
-          defaultMessage: 'WE LAUNCHED',
-        })}
-        headerBold={intl.formatMessage({
-          id: 'page.year-in-review.2020.section.we-grew.launched.heading.bold',
-          defaultMessage: 'EIGHT PROJECTS',
-        })}
-        headerEnd={intl.formatMessage({
-          id: 'page.year-in-review.2020.section.we-grew.launched.heading.end',
-          defaultMessage: 'FOR THE MOVEMENT',
-        })}
+        headerStart="WE LAUNCHED"
+        headerBold="EIGHT PROJECTS"
+        headerEnd="FOR THE MOVEMENT"
       >
         <FormattedMessage
           id="page.year-in-review.2020.section.we-grew.launched.content"
-          defaultMessage="Four of which were unique project ideas of our own! We were also lucky enough to work on projects with Animal Rebellion, Animal Save Movement, Lebanese Vegans, and the Excelsior 4!"
+          defaultMessage="Four of which were unique project ideas of our own! We were also lucky enough to work on projects with <no-localization>Animal Rebellion</no-localization>, <no-localization>Animal Save Movement</no-localization>, <no-localization>Lebanese Vegans</no-localization>, and the <no-localization>Excelsior 4</no-localization>!"
         />
       </HighlightBlock>
       <HighlightBlock
         borderColor="yellow"
-        headerStart={intl.formatMessage({
-          id: 'page.year-in-review.2020.section.we-grew.expanded.heading.start',
-          defaultMessage: 'WE EXPANDED OUR TEAM FROM',
-        })}
-        headerBold={intl.formatMessage({
-          id: 'page.year-in-review.2020.section.we-grew.expanded.heading.bold',
-          defaultMessage: '28 TO 80 VOLUNTEERS',
-        })}
+        headerStart="WE EXPANDED OUR TEAM FROM"
+        headerBold="28 TO 80 VOLUNTEERS"
       >
         <FormattedMessage
           id="page.year-in-review.2020.section.we-grew.expanded.content"
@@ -251,22 +236,13 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
       </HighlightBlock>
       <HighlightBlock
         borderColor="green"
-        headerStart={intl.formatMessage({
-          id: 'page.year-in-review.2020.section.we-grew.advisory-team.heading.start',
-          defaultMessage: 'WE NOW HAVE AN',
-        })}
-        headerBold={intl.formatMessage({
-          id: 'page.year-in-review.2020.section.we-grew.advisory-team.heading.bold',
-          defaultMessage: 'ADVISORY TEAM',
-        })}
-        headerEnd={intl.formatMessage({
-          id: 'page.year-in-review.2020.section.we-grew.advisory-team.heading.end',
-          defaultMessage: 'OF VEGAN EXPERTS',
-        })}
+        headerStart="WE NOW HAVE AN"
+        headerBold="ADVISORY TEAM"
+        headerEnd="OF VEGAN EXPERTS"
       >
         <FormattedMessage
           id="page.year-in-review.2020.section.we-grew.advisory-team.content"
-          defaultMessage="We're incredibly thankful to now have a team of experienced vegan advisors to lean on such as Seb Alex, Ryuji Chua, Leah Doellinger and Michael Dearborn. Browse more of our advisors, <link>click here!</link>"
+          defaultMessage="We're incredibly thankful to now have a team of experienced vegan advisors to lean on such as <no-localization>Seb Alex</no-localization>, <no-localization>Ryuji Chua</no-localization>, <no-localization>Leah Doellinger</no-localization> and <no-localization>Michael Dearborn</no-localization>. Browse more of our advisors, <link>click here!</link>"
           values={{
             link: (chunks) => (
               <CustomLink href="https://veganhacktivists.org/people/advisors">
@@ -298,13 +274,13 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
           spacing={4}
         >
           <FormattedMessage
-            id="page.year-in-review.2020.section.strategy-and-experimentation.content[0]"
+            id="page.year-in-review.2020.section.strategy-and-experimentation.paragraph.0"
             defaultMessage="Like 2019, we focused on building projects with little data on whether those projects would succeed. We consider this a high-risk strategy as we use hundreds of hours volunteer time on these experimental projects."
           />
         </SubSection>
         <SubSection contentSize="2xl">
           <FormattedMessage
-            id="page.year-in-review.2020.section.strategy-and-experimentation.content[1]"
+            id="page.year-in-review.2020.section.strategy-and-experimentation.paragraph.1"
             defaultMessage="We're thankful this worked last year as 3 of the 6 projects we built met our standards of success, so we continued with this methodology. We firmly believe it's important for any movement to innovate, try new tactics, build experimental tools, and strategize alternatively."
           />
         </SubSection>
@@ -339,8 +315,8 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
                 textColor="white"
               >
                 <FormattedMessage
-                  id="page.year-in-review.2020.section.community-building.volunteers.content"
-                  defaultMessage="This year we attracted volunteers that worked for Trello, Microsoft, Etsy, Better Eating, Mercy for Animals, Save Movement and Paypal!"
+                  id="page.year-in-review.2020.section.community-building.volunteers.paragraph"
+                  defaultMessage="This year we attracted volunteers that worked for <no-localization>Trello</no-localization>, <no-localization>Microsoft</no-localization>, <no-localization>Etsy</no-localization>, <no-localization>Better Eating</no-localization>, <no-localization>Mercy for Animals</no-localization>, <no-localization>Save Movement</no-localization> and <no-localization>Paypal</no-localization>!"
                 />
               </SubSection>
             </div>
@@ -361,7 +337,7 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
                 textColor="white"
               >
                 <FormattedMessage
-                  id="page.year-in-review.2020.section.community-building.our-values.content"
+                  id="page.year-in-review.2020.section.community-building.our-values.paragraph"
                   defaultMessage="We came together as a community and decided on what values we wanted to adopt, and to formalize what our mission and goals were."
                 />
               </SubSection>
@@ -377,8 +353,8 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
             textColor="white"
           >
             <FormattedMessage
-              id="page.year-in-review.2020.section.community-building.partnerships.content"
-              defaultMessage="This year we're extremely happy to have partnered with PETA, Beyond Animal, and Project Counterglow. These three partners have elevated us this year and we're so grateful to have the ability to both serve them and rely on them as our new friends."
+              id="page.year-in-review.2020.section.community-building.partnerships.paragraph"
+              defaultMessage="This year we're extremely happy to have partnered with <no-localization>PETA</no-localization>, <no-localization>Beyond Animal</no-localization>, and <no-localization>Project Counterglow</no-localization>. These three partners have elevated us this year and we're so grateful to have the ability to both serve them and rely on them as our new friends."
             />
           </SubSection>
           <div className="grid justify-center grid-cols-1 md:grid-cols-3">
@@ -411,8 +387,8 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
         </h2>
         <SubSection headerSize="3xl" contentSize="2xl" spacing={4}>
           <FormattedMessage
-            id="page.year-in-review.2020.section.new-teams.strawberry.content[0]"
-            defaultMessage="We've <link>started up a new team</link> dedicated to collecting and analyzing data not only on the projects that we build, but Vegan Hacktivists as an organization. This team marks our commitment to data, a commitment to making sure that everything we do makes a big impact, and that we're able to learn from our work in the past, as well as shaping the work we do in the future."
+            id="page.year-in-review.2020.section.new-teams.strawberry.paragraph.0"
+            defaultMessage="We've <link>started up a new team</link> dedicated to collecting and analyzing data not only on the projects that we build, but <no-localization>Vegan Hacktivists</no-localization> as an organization. This team marks our commitment to data, a commitment to making sure that everything we do makes a big impact, and that we're able to learn from our work in the past, as well as shaping the work we do in the future."
             values={{
               link: (chunks) => (
                 <CustomLink href="https://veganhacktivists.org/blog/were-assembling-a-data-and-analytics-team">
@@ -424,8 +400,8 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
         </SubSection>
         <SubSection headerSize="3xl" contentSize="2xl" spacing={4}>
           <FormattedMessage
-            id="page.year-in-review.2020.section.new-teams.strawberry.content[1]"
-            defaultMessage="Suan Chin is leading this team with 7 other data scientists. See the entire team by visiting the <link>team page here</link>. We're excited to see how this team will shape the future of the work we do!"
+            id="page.year-in-review.2020.section.new-teams.strawberry.paragraph.1"
+            defaultMessage="<no-localization>Suan Chin</no-localization> is leading this team with 7 other data scientists. See the entire team by visiting the <link>team page here</link>. We're excited to see how this team will shape the future of the work we do!"
             values={{
               link: (chunks) => (
                 <CustomLink href="/people/team">{chunks}</CustomLink>
@@ -454,8 +430,8 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
         </h2>
         <SubSection headerSize="3xl" contentSize="2xl">
           <FormattedMessage
-            id="page.year-in-review.2020.section.new-teams.blueberry.content"
-            defaultMessage="We recently introduced the Specialists team! 9 new activists have joined the team and each one currently fulfilling the roles of: Release, DevOps, Security, SEO, CSS, Art, Maps, Video, and Audio. This filled a gap where our team members could specifically get issues addressed on their projects through Team Bluebbery."
+            id="page.year-in-review.2020.section.new-teams.blueberry.paragraph"
+            defaultMessage="We recently introduced the Specialists team! 9 new activists have joined the team and each one currently fulfilling the roles of: Release, DevOps, Security, <no-localization>SEO</no-localization>, <no-localization>CSS</no-localization>, Art, Maps, Video, and Audio. This filled a gap where our team members could specifically get issues addressed on their projects through Team Blueberry."
           />
         </SubSection>
       </div>
@@ -477,8 +453,8 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
               icon: <>&#127815;</>,
               description: (
                 <FormattedMessage
-                  id="page.year-in-review.2020.section.big-impact-changes.grape.content"
-                  defaultMessage="We integrated Google Analytics into all of our projects."
+                  id="page.year-in-review.2020.section.big-impact-changes.grape.paragraph"
+                  defaultMessage="We integrated <no-localization>Google Analytics</no-localization> into all of our projects."
                 />
               ),
             },
@@ -486,8 +462,8 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
               icon: <>&#127817;</>,
               description: (
                 <FormattedMessage
-                  id="page.year-in-review.2020.section.big-impact-changes.watermelon.content"
-                  defaultMessage="We started accepting applications from Python developers."
+                  id="page.year-in-review.2020.section.big-impact-changes.watermelon.paragraph"
+                  defaultMessage="We started accepting applications from <no-localization>Python</no-localization> developers."
                 />
               ),
             },
@@ -495,7 +471,7 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
               icon: <>&#127818;</>,
               description: (
                 <FormattedMessage
-                  id="page.year-in-review.2020.section.big-impact-changes.orange.content"
+                  id="page.year-in-review.2020.section.big-impact-changes.orange.paragraph"
                   defaultMessage="We published our anonymous volunteer feedback form."
                 />
               ),
@@ -504,8 +480,8 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
               icon: <> &#127820;</>,
               description: (
                 <FormattedMessage
-                  id="page.year-in-review.2020.section.big-impact-changes.banana.content"
-                  defaultMessage="We launched our LinkedIn page for our volunteers."
+                  id="page.year-in-review.2020.section.big-impact-changes.banana.paragraph"
+                  defaultMessage="We launched our <no-localization>LinkedIn</no-localization> page for our volunteers."
                 />
               ),
             },
@@ -513,7 +489,7 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
               icon: <>&#127822;</>,
               description: (
                 <FormattedMessage
-                  id="page.year-in-review.2020.section.big-impact-changes.apple.content"
+                  id="page.year-in-review.2020.section.big-impact-changes.apple.paragraph"
                   defaultMessage="We enabled bot notifications for community events & actions."
                 />
               ),
@@ -522,7 +498,7 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
               icon: <>&#129373;</>,
               description: (
                 <FormattedMessage
-                  id="page.year-in-review.2020.section.big-impact-changes.kiwi.content"
+                  id="page.year-in-review.2020.section.big-impact-changes.kiwi.paragraph"
                   defaultMessage="We released and open-sourced several of our past projects."
                 />
               ),
@@ -531,7 +507,7 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
               icon: <>&#129365;</>,
               description: (
                 <FormattedMessage
-                  id="page.year-in-review.2020.section.big-impact-changes.carrot.content"
+                  id="page.year-in-review.2020.section.big-impact-changes.carrot.paragraph"
                   defaultMessage="We improved our on-boarding process and developer guides."
                 />
               ),
@@ -540,7 +516,7 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
               icon: <>&#127827;</>,
               description: (
                 <FormattedMessage
-                  id="page.year-in-review.2020.section.big-impact-changes.strawberry.content"
+                  id="page.year-in-review.2020.section.big-impact-changes.strawberry.paragraph"
                   defaultMessage="We installed advanced server monitoring software."
                 />
               ),
@@ -613,7 +589,7 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
               <p className="w-2/3 mb-10 font-mono text-3xl text-white">
                 <FormattedMessage
                   id="page.year-in-review.2020.section.by-the-numbers.project-statistics.courses-done"
-                  defaultMessage="COURSES DONE ON <span>VEGANBOOTCAMP.ORG</span> IN UNDER 60 DAYS"
+                  defaultMessage="COURSES DONE ON <span><no-localization>VEGANBOOTCAMP.ORG</no-localization></span> IN UNDER 60 DAYS"
                   values={{
                     span: (chunks) => (
                       <span className="font-bold">{chunks}</span>
@@ -629,7 +605,7 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
               <p className="w-2/3 mb-10 font-mono text-3xl text-white">
                 <FormattedMessage
                   id="page.year-in-review.2020.section.by-the-numbers.project-statistics.tweets"
-                  defaultMessage="TWEETS BY OUR <span>5 MINUTES 5 VEGANS</span> SUPPORT BOT"
+                  defaultMessage="TWEETS BY OUR <span><no-localization>5 MINUTES 5 VEGANS</no-localization></span> SUPPORT BOT"
                   values={{
                     span: (chunks) => (
                       <span className="font-bold">{chunks}</span>
@@ -645,7 +621,7 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
               <p className="w-2/3 font-mono text-3xl text-white">
                 <FormattedMessage
                   id="page.year-in-review.2020.section.by-the-numbers.project-statistics.groups-added"
-                  defaultMessage="ANIMAL RIGHTS GROUPS ADDED TO <span>ANIMALRIGHTSMAP.ORG</span>"
+                  defaultMessage="ANIMAL RIGHTS GROUPS ADDED TO <span><no-localization>ANIMALRIGHTSMAP.ORG</no-localization></span>"
                   values={{
                     span: (chunks) => (
                       <span className="font-bold">{chunks}</span>
@@ -661,7 +637,7 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
               <p className="w-2/3 font-mono text-3xl text-white">
                 <FormattedMessage
                   id="page.year-in-review.2020.section.by-the-numbers.project-statistics.clicks"
-                  defaultMessage="CLICKS DIRECTING ACTIVISTS TO ORGS <span>VEGANACTIVISM.ORG</span>"
+                  defaultMessage="CLICKS DIRECTING ACTIVISTS TO ORGS <span><no-localization>VEGANACTIVISM.ORG</no-localization></span>"
                   values={{
                     span: (chunks) => (
                       <span className="font-bold">{chunks}</span>
@@ -752,20 +728,20 @@ const YearInReview2020: React.FC<YearInReviewProps> = ({
         spacing={4}
       >
         <FormattedMessage
-          id="page.year-in-review.2020.section.moving-forward.content[0]"
+          id="page.year-in-review.2020.section.moving-forward.paragraph.0"
           defaultMessage="While we're happy with this years results as-well, we recognize the need to take a more data-based approach in what we build if we are to utilize our network of amazing volunteers effectively."
         />
       </SubSection>
       <SubSection contentSize="2xl" spacing={4}>
         <FormattedMessage
-          id="page.year-in-review.2020.section.moving-forward.content[1]"
+          id="page.year-in-review.2020.section.moving-forward.paragraph.1"
           defaultMessage="We also recognize that innovation often comes in uncharted territories where data is often lacking - so for 2021 we want to find a good balance of choosing projects that align with our innovation approach, while utilizing data to pick which ones may have the greater chance of impact in our movement."
         />
       </SubSection>
 
       <SubSection contentSize="2xl" spacing={4}>
         <FormattedMessage
-          id="page.year-in-review.2020.section.moving-forward.content[2]"
+          id="page.year-in-review.2020.section.moving-forward.paragraph.2"
           defaultMessage="We're really excited to hear your thoughts on our 2020 year in review, and if you like what we do, please consider supporting us by clicking the button below. Your donation ensures that all of our work and projects remain free and accessible to everyone, and we can't begin to thank you enough for the support!"
         />
       </SubSection>

--- a/translation/data/de.json
+++ b/translation/data/de.json
@@ -740,13 +740,13 @@
   "page.people.section.advisors.community.image.alt-text": {
     "message": "Unsere Gemeinschaft"
   },
-  "page.people.section.advisors.community.text": {
+  "page.people.section.advisors.community.paragraph": {
     "message": "Wir sind mehr als eine Gruppe von Freiwilligen; wir sind eine Gemeinschaft, die durch gemeinsame Werte verbunden ist und in eine Vision einer besseren Welt für Tiere investiert. Wir glauben an einen Ansatz, bei dem die Gemeinschaft an erster Stelle steht: eine Gemeinschaft, die unterstützend und wachstumsorientiert ist und für die wir gegenseitig verantwortlich sind. Wenn Sie sich angesprochen fühlen, lesen Sie weiter unten mehr."
   },
   "page.people.section.advisors.intro.heading": {
     "message": "Unsere Berater"
   },
-  "page.people.section.advisors.intro.text": {
+  "page.people.section.advisors.intro.paragraph": {
     "message": "Wir sind sehr dankbar für unser Team von erfahrenen Beratern, die der Organisation, ihrer Strategie und ihren Projekten Orientierung geben."
   },
   "page.people.section.advisors.next-seo.title": {
@@ -770,13 +770,13 @@
   "page.people.section.partners.community.image.alt-text": {
     "message": "Unsere Gemeinschaft"
   },
-  "page.people.section.partners.community.text": {
+  "page.people.section.partners.community.paragraph": {
     "message": "Wir sind mehr als eine Gruppe von Freiwilligen; wir sind eine Gemeinschaft, die durch gemeinsame Werte verbunden ist und in eine Vision einer besseren Welt für Tiere investiert. Wir glauben an einen Ansatz, bei dem die Gemeinschaft an erster Stelle steht: eine Gemeinschaft, die unterstützend und wachstumsorientiert ist und für die wir gegenseitig verantwortlich sind. Wenn Sie sich angesprochen fühlen, lesen Sie weiter unten mehr."
   },
   "page.people.section.partners.intro.heading": {
     "message": "Unsere Partner"
   },
-  "page.people.section.partners.intro.text": {
+  "page.people.section.partners.intro.paragraph": {
     "message": "Hier finden Sie Partnerorganisationen, die wir unterstützen und von denen wir unterstützt werden. Werfen Sie einen Blick darauf und erfahren Sie mehr über die großartige Arbeit, die sie leisten!"
   },
   "page.people.section.partners.next-seo.title": {
@@ -788,7 +788,7 @@
   "page.people.section.team.community.image.alt-text": {
     "message": "Unsere Gemeinschaft"
   },
-  "page.people.section.team.community.text": {
+  "page.people.section.team.community.paragraph": {
     "message": "Wir sind mehr als eine Gruppe von Freiwilligen; wir sind eine Gemeinschaft, die durch gemeinsame Werte verbunden ist und in eine Vision einer besseren Welt für Tiere investiert. Wir glauben an einen Ansatz, bei dem die Gemeinschaft an erster Stelle steht: eine Gemeinschaft, die unterstützend und wachstumsorientiert ist und für die wir gegenseitig verantwortlich sind. Wenn Sie sich angesprochen fühlen, lesen Sie weiter unten mehr."
   },
   "page.people.section.team.next-seo.title": {
@@ -803,13 +803,13 @@
   "page.people.section.volunteers.community.image.alt-text": {
     "message": "Unsere Gemeinschaft"
   },
-  "page.people.section.volunteers.community.text": {
+  "page.people.section.volunteers.community.paragraph": {
     "message": "Wir sind mehr als eine Gruppe von Freiwilligen; wir sind eine Gemeinschaft, die durch gemeinsame Werte verbunden ist und in eine Vision einer besseren Welt für Tiere investiert. Wir glauben an einen Ansatz, bei dem die Gemeinschaft an erster Stelle steht: eine Gemeinschaft, die unterstützend und wachstumsorientiert ist und für die wir gegenseitig verantwortlich sind. Wenn Sie sich angesprochen fühlen, lesen Sie weiter unten mehr."
   },
   "page.people.section.volunteers.intro.heading": {
     "message": "Unsere Freiwilligen"
   },
-  "page.people.section.volunteers.intro.text": {
+  "page.people.section.volunteers.intro.paragraph": {
     "message": "Unsere Freiwilligengemeinschaft ist das Herzstück unserer Organisation und ermöglicht es uns, innovative Projekte zu entwickeln und einen sinnvollen Beitrag zur Bewegung zu leisten. <b>Klicken Sie auf ein Symbol, um die Freiwilligen der einzelnen Teams kennenzulernen!</b>"
   },
   "page.people.section.volunteers.next-seo.title": {

--- a/translation/data/de.json
+++ b/translation/data/de.json
@@ -101,58 +101,58 @@
   "page.about.section.our-mission.section-header.image.alt-text": {
     "message": "Unser Auftrag"
   },
-  "page.about.section.our-mission.subsection-1.content": {
+  "page.about.section.our-mission.subsection-0.paragraph": {
     "message": "Um die Wirksamkeit von Projekten, Kampagnen und unserer Arbeit insgesamt zu ermitteln, müssen aussagekräftige Daten verfolgt und gesammelt werden. Wir sind der festen Überzeugung, dass eine datengesteuerte Bewegung unsere Arbeit beschleunigen und aufwerten wird. Deshalb legen wir großen Wert darauf, Daten zu ermitteln, zu sammeln und zu analysieren und sie anderen zugänglich zu machen."
   },
-  "page.about.section.our-mission.subsection-1.heading": {
+  "page.about.section.our-mission.subsection-0.heading": {
     "message": "1. Wir brauchen mehr Daten in unserer Bewegung."
   },
-  "page.about.section.our-mission.subsection-2.content": {
+  "page.about.section.our-mission.subsection-1.paragraph": {
     "message": "Wir sind der festen Überzeugung, dass Wettbewerb nicht nur gesund, sondern auch unerlässlich ist, um die Wirksamkeit unserer Bewegung zu verbessern. Der Wettbewerb übt einen gesunden Druck auf Organisationen und Projekte aus, sich ständig zu verbessern und zu wiederholen - und das gibt uns mehr Informationen darüber, was funktioniert."
   },
-  "page.about.section.our-mission.subsection-2.heading": {
+  "page.about.section.our-mission.subsection-1.heading": {
     "message": "2. Wir brauchen auch mehr Wettbewerb."
   },
-  "page.about.section.our-mission.subsection-3.content": {
+  "page.about.section.our-mission.subsection-2.paragraph": {
     "message": "Wir glauben, dass die Bewegung das Potenzial hat, in ihren Ansätzen innovativer zu sein. Wir fördern den Blick über den Tellerrand und machen Innovation zu einem zentralen Aspekt unserer Arbeit und unserer Prozesse."
   },
-  "page.about.section.our-mission.subsection-3.heading": {
+  "page.about.section.our-mission.subsection-2.heading": {
     "message": "3. Wir müssen innovativer werden."
   },
-  "page.about.section.our-mission.subsection-4.content": {
+  "page.about.section.our-mission.subsection-3.paragraph": {
     "message": "Unser Ziel ist es, Organisationen und Einzelpersonen dabei zu helfen, sich auf sinnvollere Weise zu vernetzen und zusammenzuarbeiten. Wir müssen unser Wissen nutzen und uns miteinander vernetzen, um unsere gemeinsamen Ziele zu unterstützen, sei es durch die gemeinsame Nutzung von Forschungsergebnissen oder Daten, durch den Austausch von Ressourcen oder generell durch die gegenseitige Unterstützung bei der Bewältigung organisatorischer Herausforderungen."
   },
-  "page.about.section.our-mission.subsection-4.heading": {
+  "page.about.section.our-mission.subsection-3.heading": {
     "message": "4. Und wir müssen anfangen, zusammenzuarbeiten."
   },
-  "page.about.section.our-mission.subsection-5.content": {
+  "page.about.section.our-mission.subsection-4.paragraph": {
     "message": "Nur ein winziger Prozentsatz der Weltbevölkerung lebt vegan, und nur ein Bruchteil davon ist aktiv. Viele Organisationen ermutigen Nicht-Veganer, sich aus gesundheitlichen, ökologischen oder ethischen Gründen vegan zu ernähren. Wir glauben, dass wir auch effektiv sein können, indem wir Hilfsmittel schaffen, die mehr Veganer inspirieren und motivieren, sich für die Tiere einzusetzen."
   },
-  "page.about.section.our-mission.subsection-5.heading": {
+  "page.about.section.our-mission.subsection-4.heading": {
     "message": "5. Schließlich brauchen wir mehr Veganer, die aktiv werden."
   },
   "page.about.section.our-story.next-seo.title": {
     "message": "Unsere Geschichte"
   },
-  "page.about.section.our-story.section-header.content": {
+  "page.about.section.our-story.intro.paragraph": {
     "message": "Im Jahr 2019 starteten wir unser erstes Projekt mit ein paar Freiwilligen, die sich für Aktivismus begeisterten. Seitdem sind wir zu einer Gemeinschaft hochqualifizierter und professioneller Software-Ingenieure, Designer, Datenwissenschaftler und Inhaltsersteller gewachsen, die die Bewegung unterstützen. Wir sind mit der Hoffnung angetreten, Menschen zum Handeln zu bewegen und sie zu inspirieren, sich für Tiere einzusetzen - und diesem Grundprinzip sind wir verpflichtet. Unsere digitalen Fähigkeiten beflügeln unseren Aktivismus."
   },
-  "page.about.section.our-story.section-header.heading": {
+  "page.about.section.our-story.intro.heading": {
     "message": "Unsere Geschichte"
   },
-  "page.about.section.our-story.section-header.image.alt-text": {
+  "page.about.section.our-story.image.alt-text": {
     "message": "Unsere Geschichte"
   },
-  "page.about.section.our-story.subsection-1.content": {
+  "page.about.section.our-story.paragraph.0": {
     "message": "Wir sind die Vegan Hacktivists. Unsere Fähigkeiten - sei es das Schreiben von Code, die Entwicklung einer Markenidentität oder die Analyse von Daten - sind so vielfältig wie die Regionen, aus denen wir kommen und in denen wir leben. Wir arbeiten zusammen, um Projekte zu entwickeln, die datengesteuert, experimentell und effektiv sind. Unser Kernteam besteht aus Direktoren und hochrangigen Teammitgliedern, die über Erfahrung und Fachwissen in den Bereichen Technik, Architektur, Design, Daten, Betrieb und Kommunikation verfügen. Unsere Freiwilligenbasis besteht aus Teams, die von Leitern geführt werden; jedes Team ist für ein Projekt verantwortlich, das es aktiv aufbaut und pflegt."
   },
-  "page.about.section.our-story.subsection-2.content": {
+  "page.about.section.our-story.paragraph.1": {
     "message": "Unsere Organisation verfolgt einen Ansatz, bei dem die Gemeinschaft an erster Stelle steht. Da unsere Arbeit Geduld und Engagement erfordert, regen wir unsere Freiwilligen an, indem wir ein unterstützendes Umfeld schaffen, das es ihnen ermöglicht, sich zu engagieren, effektiv und wirkungsvoll zu sein. Als dezentrale Organisation wollen wir ein Gemeinschaftsgefühl aufbauen, das sich an Werten orientiert und durch sinnvolle und spielerische Interaktionen verbunden ist. Jedes Team wird durch eine <link>Frucht oder ein Gemüse</link> repräsentiert (pflanzenbasiert auf einer anderen Ebene), und wir gleichen unsere Arbeit mit Spielen, Zusammenkünften und Gemeinschaftsanrufen aus. Unsere Freiwilligen sind schließlich das Herzstück unserer Organisation."
   },
-  "page.about.section.our-story.subsection-3.content": {
+  "page.about.section.our-story.paragraph.2": {
     "message": "Im Laufe der Jahre hat sich unsere Organisation mit den Bedürfnissen unserer Bewegung verändert. Während wir uns jetzt in erster Linie auf die Bereitstellung von Dienstleistungen zum Aufbau von Kapazitäten konzentrieren, entwickeln wir weiterhin Technologien, die wir für innovativ halten und die in der Bewegung dringend benötigt werden. Jetzt arbeiten wir intensiv mit Anwälten, Organisationen und denjenigen, die an vorderster Front arbeiten, zusammen, um ihren täglichen Betrieb, ihre Marke und Identität sowie ihre Technologie zu verbessern. Auf diese Weise tragen wir dazu bei, ihre Botschaft zu verbreiten und ihre Arbeit einem breiteren Publikum zugänglich zu machen."
   },
-  "page.about.section.our-story.subsection-4.content": {
+  "page.about.section.our-story.paragraph.3": {
     "message": "Trotz allem bleibt unser Nordstern derselbe: <no-localization>{break}</no-localization> Wir tun es für die Tiere."
   },
   "page.about.section.our-values.next-seo.title": {
@@ -167,40 +167,40 @@
   "page.about.section.our-values.section-header.image.alt-text": {
     "message": "Unsere Werte"
   },
-  "page.about.section.our-values.subsection-1.content": {
+  "page.about.section.our-values.subsection-0.paragraph": {
     "message": "Wir schätzen und respektieren das Leben aller Tiere und prangern jede Form von Gewalt und Ausbeutung gegen sie an. Wir glauben, dass Tiere das Recht haben, frei zu sein, und wir kämpfen dafür mit unserem (digitalen) Aktivismus."
   },
-  "page.about.section.our-values.subsection-1.heading": {
+  "page.about.section.our-values.subsection-0.heading": {
     "message": "Tierbefreiung"
   },
-  "page.about.section.our-values.subsection-2.content": {
+  "page.about.section.our-values.subsection-1.paragraph": {
     "message": "Wir praktizieren einen auf Liebe basierenden Organisationsansatz, bei dem die Gemeinschaft im Vordergrund steht. Wir üben uns in Empathie, Mitgefühl und Gewaltlosigkeit. Wir ermutigen jedes Mitglied zu einem offenen und freundlichen Umgang miteinander."
   },
-  "page.about.section.our-values.subsection-2.heading": {
+  "page.about.section.our-values.subsection-1.heading": {
     "message": "Gewaltlosigkeit"
   },
-  "page.about.section.our-values.subsection-3.content": {
+  "page.about.section.our-values.subsection-2.paragraph": {
     "message": "Wir glauben an den Aufbau und die Förderung von sicheren und integrativen Gemeinschaften, unabhängig von Rasse, Geschlecht, Art, Alter, sexueller Orientierung oder politischer Zugehörigkeit. Wir streben danach, vielfältig und repräsentativ für die Gemeinschaften zu sein, denen wir dienen und mit denen wir arbeiten."
   },
-  "page.about.section.our-values.subsection-3.heading": {
+  "page.about.section.our-values.subsection-2.heading": {
     "message": "Sichere Gemeinschaft"
   },
-  "page.about.section.our-values.subsection-4.content": {
+  "page.about.section.our-values.subsection-3.paragraph": {
     "message": "Wir glauben, dass Nutztiere unsere Unterstützung am dringendsten benötigen, weshalb wir uns als Organisation in erster Linie auf die Befreiung von Nutztieren konzentrieren."
   },
-  "page.about.section.our-values.subsection-4.heading": {
+  "page.about.section.our-values.subsection-3.heading": {
     "message": "Gezüchtete Tiere"
   },
-  "page.about.section.our-values.subsection-5.content": {
+  "page.about.section.our-values.subsection-4.paragraph": {
     "message": "Wir schätzen unterschiedliche Standpunkte und konstruktives Feedback von jedem Einzelnen. Wir glauben, dass jeder etwas Wertvolles zu einer Diskussion beitragen kann. Wir hören immer zuerst zu und reagieren dann konstruktiv."
   },
-  "page.about.section.our-values.subsection-5.heading": {
+  "page.about.section.our-values.subsection-4.heading": {
     "message": "Offenes Feedback"
   },
-  "page.about.section.our-values.subsection-6.content": {
+  "page.about.section.our-values.subsection-5.paragraph": {
     "message": "Wir unterstützen oder ermöglichen nicht die Ausbeutung oder Unterdrückung irgendeiner Gruppe. Wir glauben, dass die Unterdrückung von Menschen und nicht-menschlichen Tieren miteinander verbunden ist und dass die Arbeit zur Beseitigung aller Formen der Unterdrückung notwendig ist."
   },
-  "page.about.section.our-values.subsection-6.heading": {
+  "page.about.section.our-values.subsection-5.heading": {
     "message": "Anti-Oppression"
   },
   "page.blog.next-seo.title": {

--- a/translation/data/de.json
+++ b/translation/data/de.json
@@ -941,31 +941,31 @@
   "page.work.next-seo.title": {
     "message": "Unsere Arbeit"
   },
-  "page.year-in-review.2020.section.big-impact-changes.apple.content": {
+  "page.year-in-review.2020.section.big-impact-changes.apple.paragraph": {
     "message": "Wir haben Bot-Benachrichtigungen für Community-Events und -Aktionen aktiviert."
   },
-  "page.year-in-review.2020.section.big-impact-changes.banana.content": {
+  "page.year-in-review.2020.section.big-impact-changes.banana.paragraph": {
     "message": "Wir haben unsere LinkedIn-Seite für unsere Freiwilligen eingerichtet."
   },
-  "page.year-in-review.2020.section.big-impact-changes.carrot.content": {
+  "page.year-in-review.2020.section.big-impact-changes.carrot.paragraph": {
     "message": "Wir haben unseren Onboarding-Prozess und unsere Entwicklerleitfäden verbessert."
   },
-  "page.year-in-review.2020.section.big-impact-changes.grape.content": {
+  "page.year-in-review.2020.section.big-impact-changes.grape.paragraph": {
     "message": "Wir haben Google Analytics in alle unsere Projekte integriert."
   },
   "page.year-in-review.2020.section.big-impact-changes.heading": {
     "message": "Kleine Änderungen mit großer Wirkung"
   },
-  "page.year-in-review.2020.section.big-impact-changes.kiwi.content": {
+  "page.year-in-review.2020.section.big-impact-changes.kiwi.paragraph": {
     "message": "Wir haben mehrere unserer früheren Projekte veröffentlicht und als Open Source zur Verfügung gestellt."
   },
-  "page.year-in-review.2020.section.big-impact-changes.orange.content": {
+  "page.year-in-review.2020.section.big-impact-changes.orange.paragraph": {
     "message": "Wir haben unser anonymes Feedback-Formular für Freiwillige veröffentlicht."
   },
-  "page.year-in-review.2020.section.big-impact-changes.strawberry.content": {
+  "page.year-in-review.2020.section.big-impact-changes.strawberry.paragraph": {
     "message": "Wir haben eine fortschrittliche Software zur Serverüberwachung installiert."
   },
-  "page.year-in-review.2020.section.big-impact-changes.watermelon.content": {
+  "page.year-in-review.2020.section.big-impact-changes.watermelon.paragraph": {
     "message": "Wir nehmen ab sofort Bewerbungen von Python-Entwicklern entgegen."
   },
   "page.year-in-review.2020.section.by-the-numbers.2020-traffic.heading": {
@@ -1010,19 +1010,19 @@
   "page.year-in-review.2020.section.community-building.heading": {
     "message": "GEMEINSCHAFTSGEBÄUDE"
   },
-  "page.year-in-review.2020.section.community-building.our-values.content": {
+  "page.year-in-review.2020.section.community-building.our-values.paragraph": {
     "message": "Wir kamen als Gemeinschaft zusammen und beschlossen, welche Werte wir uns zu eigen machen wollten, und formulierten unseren Auftrag und unsere Ziele."
   },
   "page.year-in-review.2020.section.community-building.our-values.heading": {
     "message": "Unsere Werte"
   },
-  "page.year-in-review.2020.section.community-building.partnerships.content": {
+  "page.year-in-review.2020.section.community-building.partnerships.paragraph": {
     "message": "In diesem Jahr sind wir sehr froh, mit PETA, Beyond Animal und Project Counterglow zusammenzuarbeiten. Diese drei Partner haben uns in diesem Jahr zu neuen Höhenflügen verholfen, und wir sind sehr dankbar, dass wir ihnen dienen und uns auf sie als unsere neuen Freunde verlassen können."
   },
   "page.year-in-review.2020.section.community-building.partnerships.heading": {
     "message": "Partnerschaften"
   },
-  "page.year-in-review.2020.section.community-building.volunteers.content": {
+  "page.year-in-review.2020.section.community-building.volunteers.paragraph": {
     "message": "Dieses Jahr konnten wir Freiwillige gewinnen, die für Trello, Microsoft, Etsy, Better Eating, Mercy for Animals, Save Movement und Paypal arbeiteten!"
   },
   "page.year-in-review.2020.section.community-building.volunteers.heading": {
@@ -1031,55 +1031,55 @@
   "page.year-in-review.2020.section.header.image.alt-text": {
     "message": "Jahresrückblick 2020"
   },
-  "page.year-in-review.2020.section.highlighted-projects.animal-rights-map.content": {
+  "page.year-in-review.2020.section.highlighted-projects.animal-rights-map.paragraph": {
     "message": "Mit über 2.500 Gruppen ist die Animal Rights Map eine weltweit aktualisierte Karte, die Veganern hilft, lokale Gruppen zu finden, bei denen sie aktiv werden können. Unsere Karte enthält alle, von den größten Organisationen bis hin zu den sehr kleinen Basisgruppen, die über das ganze Land verteilt sind. Wir haben mit einigen Organisationen zusammengearbeitet, um neue Gruppen automatisch zu importieren, und wir haben einen engagierten Freiwilligen (der dieses Projekt ins Leben gerufen hat), der die Karte fast jeden Tag akribisch aktualisiert. Wir haben viel tolles Feedback für die Karte von Veganern erhalten, die aktiv werden wollen - wir planen, bald mehr Daten zu sammeln und die Funktionen dieser Karte für 2021 zu erweitern!"
   },
-  "page.year-in-review.2020.section.highlighted-projects.daily-nooch.content": {
+  "page.year-in-review.2020.section.highlighted-projects.daily-nooch.paragraph": {
     "message": "Mit diesem Projekt wollten wir etwas schaffen, das ein wenig mehr Spaß macht und leicht ist, das Veganer gerne konsumieren und mit der Welt teilen können. Daily Nooch ist Ihre zentrale Anlaufstelle für tägliche vegane Nachrichten, Ressourcen und Inspiration. Als Startseite konzipiert, finden Sie hier jeden Tag um Mitternacht die neuesten Nachrichten, Zitate, Kunst, Memes, Fakten, Videos und mehr. Dieses Projekt ist noch sehr experimentell und wir wissen nicht, ob Veganer es konsequent nutzen werden, aber in der Zwischenzeit hatte das Team eine Menge Spaß bei der Erstellung. Wenn es den Leuten gefällt, haben wir eine Reihe lustiger Ideen, die dem Projekt mehr Interaktivität verleihen werden."
   },
   "page.year-in-review.2020.section.highlighted-projects.heading": {
     "message": "Siehe unsere HIGHLIGHTED PROJECTS"
   },
-  "page.year-in-review.2020.section.highlighted-projects.my-daily-dozen.content": {
+  "page.year-in-review.2020.section.highlighted-projects.my-daily-dozen.paragraph": {
     "message": "Dr. Greger, der Gründer von NutritionFacts.org, hat eine App mit dem Namen \"Daily Dozen\" entwickelt, mit der Sie Ihre Ernährung verfolgen und sicherstellen können, dass Sie sich optimal ernähren - und die die gesündesten Lebensmittel und die Anzahl der Portionen auflistet, die wir täglich abhaken sollten. Wir wollten dieses Konzept erweitern und eine webbasierte Version seiner App mit einigen zusätzlichen Funktionen erstellen. Mit My Daily Dozen können Sie täglich die von Dr. Greger in seinem New York Times-Bestseller How Not to Die empfohlenen Lebensmittel verfolgen. Wir hoffen, dass dieses Projekt Nicht-Veganern den Weg zum Veganismus erleichtert, indem sie einen pflanzlichen Lebensstil annehmen."
   },
-  "page.year-in-review.2020.section.highlighted-projects.vegan-bootcamp.content": {
+  "page.year-in-review.2020.section.highlighted-projects.vegan-bootcamp.paragraph": {
     "message": "Nach dem erfolgreichen Start des Vegan Bootcamp im Jahr 2019 mit über 5000+ Anmeldungen haben wir beschlossen, mehr Zeit in die Verbesserung des Programms zu investieren. Wir haben eine Umfrage an alle Mitglieder verschickt und eine große Menge an Feedback erhalten, das uns geholfen hat zu entscheiden, welche neuen Inhalte und Funktionen benötigt werden. Vegan Bootcamp umfasst jetzt Community-Foren, individuelle Kurse, Tags, bessere Belohnungen, erweiterte Statistiken für Empfehlungen, eine Inhaltssuche, ein Unterstützungsprogramm für vegane Ernährungsberater, ein Mentorenprogramm und ist jetzt in 10 verschiedene Sprachen übersetzt!"
   },
   "page.year-in-review.2020.section.moving-forward.btn.text": {
     "message": "Unterstützen Sie unsere Arbeit!"
   },
-  "page.year-in-review.2020.section.moving-forward.content[0]": {
+  "page.year-in-review.2020.section.moving-forward.paragraph.0": {
     "message": "Auch wenn wir mit den diesjährigen Ergebnissen zufrieden sind, erkennen wir die Notwendigkeit eines stärker datenbasierten Ansatzes, wenn wir unser Netzwerk von fantastischen Freiwilligen effektiv nutzen wollen."
   },
-  "page.year-in-review.2020.section.moving-forward.content[1]": {
+  "page.year-in-review.2020.section.moving-forward.paragraph.1": {
     "message": "Wir sind uns auch darüber im Klaren, dass Innovation oft auf unbekanntem Terrain stattfindet, wo es oft an Daten mangelt. Daher wollen wir für 2021 ein ausgewogenes Verhältnis zwischen der Auswahl von Projekten, die mit unserem Innovationsansatz übereinstimmen, und der Nutzung von Daten finden, um herauszufinden, welche Projekte die größten Auswirkungen auf unsere Bewegung haben könnten."
   },
-  "page.year-in-review.2020.section.moving-forward.content[2]": {
+  "page.year-in-review.2020.section.moving-forward.paragraph.2": {
     "message": "Wir sind sehr gespannt auf Ihre Meinung zu unserem Jahresrückblick 2020. Wenn Ihnen gefällt, was wir tun, sollten Sie uns unterstützen, indem Sie auf die Schaltfläche unten klicken. Mit Ihrer Spende stellen Sie sicher, dass unsere Arbeit und unsere Projekte weiterhin kostenlos und für alle zugänglich sind. Wir können Ihnen gar nicht genug für Ihre Unterstützung danken!"
   },
   "page.year-in-review.2020.section.moving-forward.heading": {
     "message": "Schluss machen und weitermachen!"
   },
-  "page.year-in-review.2020.section.new-teams.blueberry.content": {
+  "page.year-in-review.2020.section.new-teams.blueberry.paragraph": {
     "message": "Wir haben kürzlich das Team der Spezialisten vorgestellt! 9 neue Aktivisten sind dem Team beigetreten und jeder von ihnen erfüllt derzeit die Rollen von: Release, DevOps, Sicherheit, SEO, CSS, Kunst, Karten, Video und Audio. Dies füllte eine Lücke, in der unsere Teammitglieder gezielt Probleme in ihren Projekten durch das Team Bluebbery angegangen werden konnten."
   },
   "page.year-in-review.2020.section.new-teams.blueberry.heading": {
     "message": "<span>Fachleute</span> | Team Blueberry"
   },
-  "page.year-in-review.2020.section.new-teams.strawberry.content[0]": {
+  "page.year-in-review.2020.section.new-teams.strawberry.paragraph.0": {
     "message": "Wir haben <link>ein neues Team gegründet</link>, das sich der Sammlung und Analyse von Daten widmet, nicht nur über die Projekte, die wir entwickeln, sondern auch über Vegan Hacktivists als Organisation. Dieses Team steht für unser Engagement für Daten, ein Engagement, das sicherstellt, dass alles, was wir tun, eine große Wirkung hat, und dass wir in der Lage sind, aus unserer Arbeit in der Vergangenheit zu lernen und die Arbeit, die wir in der Zukunft tun, zu gestalten."
   },
-  "page.year-in-review.2020.section.new-teams.strawberry.content[1]": {
+  "page.year-in-review.2020.section.new-teams.strawberry.paragraph.1": {
     "message": "Suan Chin leitet dieses Team mit 7 weiteren Datenwissenschaftlern. Das gesamte Team finden Sie auf der <link>Teamseite hier</link>. Wir sind gespannt, wie dieses Team die Zukunft unserer Arbeit gestalten wird!"
   },
   "page.year-in-review.2020.section.new-teams.strawberry.heading": {
     "message": "<span>Datenanalyse</span> | Team Strawberry"
   },
-  "page.year-in-review.2020.section.strategy-and-experimentation.content[0]": {
+  "page.year-in-review.2020.section.strategy-and-experimentation.paragraph.0": {
     "message": "Wie 2019 haben wir uns auf die Entwicklung von Projekten konzentriert, ohne dass wir wussten, ob diese Projekte erfolgreich sein würden. Wir betrachten dies als eine risikoreiche Strategie, da wir Hunderte von Stunden ehrenamtlicher Arbeit in diese experimentellen Projekte investieren."
   },
-  "page.year-in-review.2020.section.strategy-and-experimentation.content[1]": {
+  "page.year-in-review.2020.section.strategy-and-experimentation.paragraph.1": {
     "message": "Wir sind dankbar, dass dies im letzten Jahr funktioniert hat, denn 3 der 6 Projekte, die wir aufgebaut haben, erfüllten unsere Erfolgsstandards, so dass wir mit dieser Methodik fortfuhren. Wir glauben fest daran, dass es für jede Bewegung wichtig ist, innovativ zu sein, neue Taktiken auszuprobieren, experimentelle Werkzeuge zu entwickeln und alternative Strategien zu entwickeln."
   },
   "page.year-in-review.2020.section.strategy-and-experimentation.heading": {
@@ -1124,19 +1124,19 @@
   "page.year-in-review.2020.section.we-grew.launched.heading.start": {
     "message": "WIR HABEN GESTARTET"
   },
-  "page.year-in-review.2020.section.working-with-organizations.animal-rebellion.content": {
+  "page.year-in-review.2020.section.working-with-organizations.animal-rebellion.paragraph": {
     "message": "Wir haben uns dieses Jahr mit Animal Rebellion zusammengetan, um bei der Erstellung ihrer neuen Website zu helfen, für die wir ein ganzes Team abgestellt haben, das etwa 6 Monate Arbeit benötigte. Die Zusammenarbeit mit ihrem technischen Team war fantastisch, sie waren sehr sachkundig und wir hatten das Gefühl, dass wir bei jeder Begegnung während unserer Arbeit mit einem Team von Profis zusammenarbeiteten. Animal Rebellion ist eine Massenbewegung, die mit gewaltfreiem zivilem Widerstand den Übergang zu einem gerechten und nachhaltigen pflanzlichen Lebensmittelsystem herbeiführen will, um das Massensterben zu stoppen, die schlimmsten Auswirkungen des Klimawandels abzumildern und Gerechtigkeit für Tiere zu gewährleisten."
   },
   "page.year-in-review.2020.section.working-with-organizations.animal-rebellion.heading": {
     "message": "Rebellion der Tiere"
   },
-  "page.year-in-review.2020.section.working-with-organizations.animal-save-movement.content": {
+  "page.year-in-review.2020.section.working-with-organizations.animal-save-movement.paragraph": {
     "message": "Wir durften mit Animal Save zusammenarbeiten und ihnen bei ihrer neuen Website helfen. Wir halfen auch bei ihrer Werbekampagne und betreuten diese für einige Monate, um die Arbeit und den Newsletter von Save bekannter zu machen. Falls Sie noch nichts von Save gehört haben: Die Organisation hat es sich zur Aufgabe gemacht, vor jedem Schlachthof Mahnwachen abzuhalten und für jedes ausgebeutete Tier Zeugnis abzulegen. Sie leiten auch die Klima- und Gesundheits-Save-Bewegung, die sich für die Umkehrung des katastrophalen Klimawandels und eine pflanzliche Ernährung einsetzt. Es war eine große Freude, ihr Team von leidenschaftlichen Aktivisten kennenzulernen und mit ihnen zusammenzuarbeiten!"
   },
   "page.year-in-review.2020.section.working-with-organizations.animal-save-movement.heading": {
     "message": "Tierschutz-Bewegung"
   },
-  "page.year-in-review.2020.section.working-with-organizations.excelsior.content": {
+  "page.year-in-review.2020.section.working-with-organizations.excelsior.paragraph": {
     "message": "Die Excelsior 4 sind vier Aktivisten, die wegen der Aufdeckung krimineller Tierquälerei auf der Excelsior Hog Farm in insgesamt 21 Fällen angeklagt sind. Wir haben mit ihnen zusammengearbeitet, um eine neue Website einzurichten, die es ihnen ermöglichen würde, so schnell wie möglich Spenden für ihre rechtliche Verteidigung zu sammeln. Wir sind der Meinung, dass die Arbeit, die sie geleistet haben, und das, was sie aufgedeckt haben, extrem wichtig ist, und wir sind sehr froh, dass wir die Möglichkeit hatten, sie zu unterstützen und ihnen dabei zu helfen, die Seite zum Laufen zu bringen. Bitte besuchen Sie sie und unterstützen Sie sie, wenn Sie können!"
   },
   "page.year-in-review.2020.section.working-with-organizations.excelsior.heading": {
@@ -1145,7 +1145,7 @@
   "page.year-in-review.2020.section.working-with-organizations.heading": {
     "message": "Arbeit mit ORGANISATIONEN"
   },
-  "page.year-in-review.2020.section.working-with-organizations.lebanese-vegans.content": {
+  "page.year-in-review.2020.section.working-with-organizations.lebanese-vegans.paragraph": {
     "message": "Das soziale Zentrum der libanesischen Veganer ist das einzige Zentrum für Tierrechte und die Unterstützung von Veganern in Südwestasien und Nordafrika. Es bietet monatlich kostenlose Workshops und Vorträge über Veganismus, verteilt wöchentlich kostenlos Lebensmittel und führt monatliche Kampagnen zur Sensibilisierung für Tierrechte durch. Wir hatten das Glück, mit ihnen zusammenzuarbeiten, um ihnen sowohl bei der Einführung ihrer neuen Website als auch beim Re-Branding mit einem neuen Logo zu helfen. Die Zusammenarbeit mit unserem Berater Seb Alex, der die Arbeit von Lebanese Vegans organisiert, war sehr angenehm."
   },
   "page.year-in-review.2020.section.working-with-organizations.lebanese-vegans.heading": {

--- a/translation/data/de.json
+++ b/translation/data/de.json
@@ -305,13 +305,13 @@
   "page.grants.section.application.form.a.input.applicant-gender.label": {
     "message": "Geschlecht <span>(fakultativ)</span>"
   },
-  "page.grants.section.application.form.a.input.applicant-gender.option[0]": {
+  "page.grants.section.application.form.a.input.applicant-gender.option.0": {
     "message": "männlich"
   },
-  "page.grants.section.application.form.a.input.applicant-gender.option[1]": {
+  "page.grants.section.application.form.a.input.applicant-gender.option.1": {
     "message": "weiblich"
   },
-  "page.grants.section.application.form.a.input.applicant-gender.option[2]": {
+  "page.grants.section.application.form.a.input.applicant-gender.option.2": {
     "message": "andere"
   },
   "page.grants.section.application.form.a.input.applicant-gender.placeholder": {
@@ -428,19 +428,19 @@
   "page.grants.section.heading.text": {
     "message": "Zuschüsse für die Anschubfinanzierung"
   },
-  "page.grants.section.perks.check-ins.content": {
+  "page.grants.section.perks.check-ins.paragraph": {
     "message": "Ein monatlicher 30-minütiger Zoom-Anruf, um Sie und Ihr Team zu beraten. Die Themen umfassen unter anderem Technologie, Marketing, Strategie und andere Aspekte des Wachstums und der Entwicklung Ihrer Organisation."
   },
   "page.grants.section.perks.check-ins.heading": {
     "message": "Monatliche Beratungsbesuche"
   },
-  "page.grants.section.perks.content-dev.content": {
+  "page.grants.section.perks.content-dev.paragraph": {
     "message": "Wir helfen Ihnen bei der Erstellung von Botschaften für die Öffentlichkeit, einschließlich Website-Texten. Wir bieten unsere Schreib- und Redaktionsfähigkeiten in jeder Phase des Prozesses an: vom ersten Brainstorming bis zur Überprüfung von Texten, die Ihre Arbeit fördern."
   },
   "page.grants.section.perks.content-dev.heading": {
     "message": "Entwicklung von Inhalten"
   },
-  "page.grants.section.perks.design-creation.content": {
+  "page.grants.section.perks.design-creation.paragraph": {
     "message": "Je nach Ihren Bedürfnissen entwerfen wir das Branding und das Logo für Ihre Organisation oder Ihr Projekt (oder gestalten es neu). Außerdem stellen wir digitale Assets wie Banner, Icons und andere benutzerdefinierte Elemente für soziale Medien und Ihre Website bereit."
   },
   "page.grants.section.perks.design-creation.heading": {
@@ -452,7 +452,7 @@
   "page.grants.section.perks.heading.image.alt-text": {
     "message": "Zusätzlich zur Startfinanzierung können erfolgreiche Antragsteller Folgendes erhalten:"
   },
-  "page.grants.section.perks.squarespace.content": {
+  "page.grants.section.perks.squarespace.paragraph": {
     "message": "<div>Im Wert von 200 $ übernehmen wir die Abonnementkosten für das erste Jahr.</div> <div>Sie sind der Eigentümer, und wir helfen Ihnen bei der Gestaltung und Pflege der Website.</div> <div>Einfach zu aktualisieren mit wenig bis gar keiner Erfahrung.</div>"
   },
   "page.grants.section.perks.squarespace.heading": {
@@ -461,28 +461,28 @@
   "page.grants.section.pollination-project.button": {
     "message": "DasBestäubungsprojekt.org"
   },
-  "page.grants.section.pollination-project.content[0]": {
+  "page.grants.section.pollination-project.paragraph.0": {
     "message": "Unser Zuschussvermittlungsdienst wird großzügig von The Pollination Project (TPP) und anderen privaten Spendern finanziert - bitte halten Sie in Ihrem Posteingang Ausschau und vergessen Sie nicht, Ihre Spam-Mails zu überprüfen!"
   },
-  "page.grants.section.pollination-project.content[1]": {
+  "page.grants.section.pollination-project.paragraph.1": {
     "message": "Wenn Ihr Hauptaugenmerk nicht auf Nutztiere gerichtet ist, können Sie trotzdem für einen Zuschuss direkt von TPP in Frage kommen. Wir empfehlen Ihnen, sich über die Website zu bewerben."
   },
   "page.grants.section.pollination-project.image.alt-text": {
     "message": "Logo von The Pollination Project"
   },
-  "page.grants.section.qualifications.cta[0].content": {
+  "page.grants.section.qualifications.cta.paragraph.0": {
     "message": "<b>Erfüllen Sie die oben genannten Voraussetzungen nicht?</b> Sie könnten trotzdem für eine Förderung in Frage kommen! Bewerben Sie sich und wir leiten Ihre Bewerbung an andere potenzielle Geldgeber weiter."
   },
-  "page.grants.section.qualifications.cta[1].content": {
+  "page.grants.section.qualifications.cta.paragraph.1": {
     "message": "Wenn Sie die Voraussetzungen erfüllen, füllen Sie bitte das nachstehende Bewerbungsformular aus."
   },
   "page.grants.section.qualifications.heading": {
     "message": "Vergewissern Sie sich vor Ihrer Bewerbung, dass Sie diese Voraussetzungen erfüllen:"
   },
-  "page.grants.section.qualifications.step[0].content": {
+  "page.grants.section.qualifications.steps.paragraph.0": {
     "message": "<b> Ihr vorrangiges Ziel </b> sollte es sein, das Leiden von Nutztieren zu verringern. In der Massentierhaltung leiden jedes Jahr über 100 Milliarden Tiere unter Entbehrungen, Angst und Schmerzen."
   },
-  "page.grants.section.qualifications.step[1].content": {
+  "page.grants.section.qualifications.steps.paragraph.1": {
     "message": "<b> Sie müssen </b> bereits Erfahrung im Aktivismus haben, sei es im Bereich der Tierrechte oder in anderen sozialen Bewegungen. Wir suchen Menschen, die an Basis-Kampagnen und/oder -Projekten mitgewirkt haben, sei es in einer bezahlten oder ehrenamtlichen Funktion."
   },
   "page.grants.section.subheading": {

--- a/translation/data/en.json
+++ b/translation/data/en.json
@@ -651,7 +651,7 @@
     "message": "Applicants"
   },
   "page.our-work.section.grant-program.section-header.content": {
-    "message": "Last year, we announced a partnership with The Pollination Project to offer seed funding to individuals and grassroots organizations. Here’s what we’ve accomplished to date."
+    "message": "Last year, we announced a partnership with <no-localization>The Pollination Project</no-localization> to offer seed funding to individuals and grassroots organizations. Here’s what we’ve accomplished to date."
   },
   "page.our-work.section.grant-program.section-header.learn-more.cta-button.label": {
     "message": "Learn more"
@@ -662,17 +662,41 @@
   "page.our-work.section.hours-volunteered.cta-button.label": {
     "message": "volunteered in 2022 for the animal protection movement"
   },
+  "page.our-work.section.kind-words[0].author": {
+    "message": "<no-localization>Courtney Dillard</no-localization>"
+  },
+  "page.our-work.section.kind-words[0].company": {
+    "message": "<no-localization>Mercy for Animals</no-localization>"
+  },
   "page.our-work.section.kind-words[0].content": {
-    "message": "What impresses me most about the Vegan Hacktivists is their high level of critical thinking in terms of ideation and their consistent follow through. This has resulted in several high level deliverables I have been able to use and highly recommended to others."
+    "message": "What impresses me most about the <no-localization>Vegan Hacktivists</no-localization> is their high level of critical thinking in terms of ideation and their consistent follow through. This has resulted in several high level deliverables I have been able to use and highly recommended to others."
+  },
+  "page.our-work.section.kind-words[1].author": {
+    "message": "<no-localization>Ben Williamson</no-localization>"
+  },
+  "page.our-work.section.kind-words[1].company": {
+    "message": "<no-localization>Compassion In World Farming</no-localization>"
   },
   "page.our-work.section.kind-words[1].content": {
-    "message": "I’m really excited by the potential Vegan Hacktivists have for the animal protection movement. Progress is full of tipping points, and I’m sure at least one of these lives within a technological solution offered by this skilled community of advocates."
+    "message": "I’m really excited by the potential <no-localization>Vegan Hacktivists</no-localization> have for the animal protection movement. Progress is full of tipping points, and I’m sure at least one of these lives within a technological solution offered by this skilled community of advocates."
+  },
+  "page.our-work.section.kind-words[2].author": {
+    "message": "<no-localization>AJ Dahiya</no-localization>"
+  },
+  "page.our-work.section.kind-words[2].company": {
+    "message": "<no-localization>The Pollination Project</no-localization>"
   },
   "page.our-work.section.kind-words[2].content": {
-    "message": "Vegan Hacktivists is an innovative organization leveraging technology to make a large-scale impact for the rights and dignity of animals. They have gone above and beyond in supporting our organization with their expertise. Their work is extremely needed and on the cutting edge for the time we live in."
+    "message": "<no-localization>Vegan Hacktivists</no-localization> is an innovative organization leveraging technology to make a large-scale impact for the rights and dignity of animals. They have gone above and beyond in supporting our organization with their expertise. Their work is extremely needed and on the cutting edge for the time we live in."
+  },
+  "page.our-work.section.kind-words[3].author": {
+    "message": "<no-localization>Brooke Haggerty</no-localization>"
+  },
+  "page.our-work.section.kind-words[3].company": {
+    "message": "<no-localization>Faunalytics</no-localization>"
   },
   "page.our-work.section.kind-words[3].content": {
-    "message": "Vegan Hacktivists is a hidden gem in the animal protection movement. They are capacity builders, dedicated to supporting other animal advocates. We’ve been fortunate enough to receive their help with several behind the scenes projects, and I’m constantly impressed with their passion and professionalism."
+    "message": "<no-localization>Vegan Hacktivists</no-localization> is a hidden gem in the animal protection movement. They are capacity builders, dedicated to supporting other animal advocates. We’ve been fortunate enough to receive their help with several behind the scenes projects, and I’m constantly impressed with their passion and professionalism."
   },
   "page.our-work.section.like-what-you-see.contact.cta-button.label": {
     "message": "Contact us"
@@ -689,8 +713,11 @@
   "page.our-work.section.like-what-you-see.services.cta-button.label": {
     "message": "Services"
   },
+  "page.our-work.section.our-communities.cta.animal-rights-advocates": {
+    "message": "<no-localization>Animal Rights Advocates</no-localization>"
+  },
   "page.our-work.section.our-communities.cta.reddit": {
-    "message": "Vegans of Reddit"
+    "message": "Vegans of <no-localization>Reddit</no-localization>"
   },
   "page.our-work.section.our-communities.member-count.ara": {
     "message": "<no-localization>{count}</no-localization> members"
@@ -717,16 +744,28 @@
     "message": "Get Support"
   },
   "page.our-work.section.playground.introduction": {
-    "message": "<p>Playground was our response to meet the overwhelming demand of tech and design support in our movement, while staying sustainable as an organization with limited capacity. We prioritized automating the process of connecting organizations with technical, design, and other support needs with skilled volunteers.</p> <p>Beyond design and software development, these volunteers are professionals with a wide array of skills and backgrounds in data science, videography, marketing, security, research, and much more.</p>"
+    "message": "<p><no-localization>Playground</no-localization> was our response to meet the overwhelming demand of tech and design support in our movement, while staying sustainable as an organization with limited capacity. We prioritized automating the process of connecting organizations with technical, design, and other support needs with skilled volunteers.</p> <p>Beyond design and software development, these volunteers are professionals with a wide array of skills and backgrounds in data science, videography, marketing, security, research, and much more.</p>"
   },
   "page.our-work.section.playground.playground.cta-button.label": {
     "message": "Volunteer"
   },
+  "page.our-work.section.sharing-knowledge-and-support.conferences.1.caption": {
+    "message": "<no-localization>Malina Tran</no-localization> at <no-localization>CARE</no-localization> Conference"
+  },
+  "page.our-work.section.sharing-knowledge-and-support.conferences.1.subcaption": {
+    "message": "Data & Tech in Animal Rights Activism"
+  },
+  "page.our-work.section.sharing-knowledge-and-support.conferences.2.caption": {
+    "message": "<no-localization>James Morgan</no-localization> at <no-localization>AVA Summit</no-localization>"
+  },
+  "page.our-work.section.sharing-knowledge-and-support.conferences.2.subcaption": {
+    "message": "Tech Innovation in Animal Protection"
+  },
   "page.our-work.section.sharing-knowledge-and-support.section-header.content": {
-    "message": "We're often speaking at animal protection and EA related conferences every year and around the world! Be sure to look out for our booth or speakers, we'd love to meet you and see where we might be able to support your work. Follow us on <link>Instagram</link> to see where we'll be next!"
+    "message": "We're often speaking at animal protection and <no-localization>EA</no-localization> related conferences every year and around the world! Be sure to look out for our booth or speakers, we'd love to meet you and see where we might be able to support your work. Follow us on <no-localization><link>Instagram</link></no-localization> to see where we'll be next!"
   },
   "page.our-work.section.state-of-data.content": {
-    "message": "We launched the first-of-its-kind study to understand how our movement leverages technology. With guidance from Faunalytics and research conducted by Animetrics, our 50-page report explores challenges and opportunities across various topics such as employment and workforce, websites and applications, social media, data collection and analysis, and security. Our recommendations are meant to provide actionable solutions for stakeholders and community members on how we can become a more technological, data-driven movement."
+    "message": "We launched the first-of-its-kind study to understand how our movement leverages technology. With guidance from <no-localization>Faunalytics</no-localization> and research conducted by <no-localization>Animetrics</no-localization>, our 50-page report explores challenges and opportunities across various topics such as employment and workforce, websites and applications, social media, data collection and analysis, and security. Our recommendations are meant to provide actionable solutions for stakeholders and community members on how we can become a more technological, data-driven movement."
   },
   "page.our-work.section.state-of-data.cta": {
     "message": "Read the report"

--- a/translation/data/en.json
+++ b/translation/data/en.json
@@ -941,32 +941,32 @@
   "page.work.next-seo.title": {
     "message": "Our Work"
   },
-  "page.year-in-review.2020.section.big-impact-changes.apple.content": {
+  "page.year-in-review.2020.section.big-impact-changes.apple.paragraph": {
     "message": "We enabled bot notifications for community events & actions."
   },
-  "page.year-in-review.2020.section.big-impact-changes.banana.content": {
-    "message": "We launched our LinkedIn page for our volunteers."
+  "page.year-in-review.2020.section.big-impact-changes.banana.paragraph": {
+    "message": "We launched our <no-localization>LinkedIn</no-localization> page for our volunteers."
   },
-  "page.year-in-review.2020.section.big-impact-changes.carrot.content": {
+  "page.year-in-review.2020.section.big-impact-changes.carrot.paragraph": {
     "message": "We improved our on-boarding process and developer guides."
   },
-  "page.year-in-review.2020.section.big-impact-changes.grape.content": {
-    "message": "We integrated Google Analytics into all of our projects."
+  "page.year-in-review.2020.section.big-impact-changes.grape.paragraph": {
+    "message": "We integrated <no-localization>Google Analytics</no-localization> into all of our projects."
   },
   "page.year-in-review.2020.section.big-impact-changes.heading": {
     "message": "Minor changes with a BIG IMPACT"
   },
-  "page.year-in-review.2020.section.big-impact-changes.kiwi.content": {
+  "page.year-in-review.2020.section.big-impact-changes.kiwi.paragraph": {
     "message": "We released and open-sourced several of our past projects."
   },
-  "page.year-in-review.2020.section.big-impact-changes.orange.content": {
+  "page.year-in-review.2020.section.big-impact-changes.orange.paragraph": {
     "message": "We published our anonymous volunteer feedback form."
   },
-  "page.year-in-review.2020.section.big-impact-changes.strawberry.content": {
+  "page.year-in-review.2020.section.big-impact-changes.strawberry.paragraph": {
     "message": "We installed advanced server monitoring software."
   },
-  "page.year-in-review.2020.section.big-impact-changes.watermelon.content": {
-    "message": "We started accepting applications from Python developers."
+  "page.year-in-review.2020.section.big-impact-changes.watermelon.paragraph": {
+    "message": "We started accepting applications from <no-localization>Python</no-localization> developers."
   },
   "page.year-in-review.2020.section.by-the-numbers.2020-traffic.heading": {
     "message": "OUR 2020 TRAFFIC"
@@ -990,19 +990,19 @@
     "message": "UNIQUE <b>PAGE VIEWS</b> ON THE BLOG"
   },
   "page.year-in-review.2020.section.by-the-numbers.project-statistics.clicks": {
-    "message": "CLICKS DIRECTING ACTIVISTS TO ORGS <span>VEGANACTIVISM.ORG</span>"
+    "message": "CLICKS DIRECTING ACTIVISTS TO ORGS <span><no-localization>VEGANACTIVISM.ORG</no-localization></span>"
   },
   "page.year-in-review.2020.section.by-the-numbers.project-statistics.courses-done": {
-    "message": "COURSES DONE ON <span>VEGANBOOTCAMP.ORG</span> IN UNDER 60 DAYS"
+    "message": "COURSES DONE ON <span><no-localization>VEGANBOOTCAMP.ORG</no-localization></span> IN UNDER 60 DAYS"
   },
   "page.year-in-review.2020.section.by-the-numbers.project-statistics.groups-added": {
-    "message": "ANIMAL RIGHTS GROUPS ADDED TO <span>ANIMALRIGHTSMAP.ORG</span>"
+    "message": "ANIMAL RIGHTS GROUPS ADDED TO <span><no-localization>ANIMALRIGHTSMAP.ORG</no-localization></span>"
   },
   "page.year-in-review.2020.section.by-the-numbers.project-statistics.heading": {
     "message": "PROJECT STATISTICS"
   },
   "page.year-in-review.2020.section.by-the-numbers.project-statistics.tweets": {
-    "message": "TWEETS BY OUR <span>5 MINUTES 5 VEGANS</span> SUPPORT BOT"
+    "message": "TWEETS BY OUR <span><no-localization>5 MINUTES 5 VEGANS</no-localization></span> SUPPORT BOT"
   },
   "page.year-in-review.2020.section.by-the-numbers.top-posts": {
     "message": "TOP POSTS"
@@ -1010,101 +1010,86 @@
   "page.year-in-review.2020.section.community-building.heading": {
     "message": "COMMUNITY BUILDING"
   },
-  "page.year-in-review.2020.section.community-building.our-values.content": {
-    "message": "We came together as a community and decided on what values we wanted to adopt, and to formalize what our mission and goals were."
-  },
   "page.year-in-review.2020.section.community-building.our-values.heading": {
     "message": "Our Values"
   },
-  "page.year-in-review.2020.section.community-building.partnerships.content": {
-    "message": "This year we're extremely happy to have partnered with PETA, Beyond Animal, and Project Counterglow. These three partners have elevated us this year and we're so grateful to have the ability to both serve them and rely on them as our new friends."
+  "page.year-in-review.2020.section.community-building.our-values.paragraph": {
+    "message": "We came together as a community and decided on what values we wanted to adopt, and to formalize what our mission and goals were."
   },
   "page.year-in-review.2020.section.community-building.partnerships.heading": {
     "message": "Partnerships"
   },
-  "page.year-in-review.2020.section.community-building.volunteers.content": {
-    "message": "This year we attracted volunteers that worked for Trello, Microsoft, Etsy, Better Eating, Mercy for Animals, Save Movement and Paypal!"
+  "page.year-in-review.2020.section.community-building.partnerships.paragraph": {
+    "message": "This year we're extremely happy to have partnered with <no-localization>PETA</no-localization>, <no-localization>Beyond Animal</no-localization>, and <no-localization>Project Counterglow</no-localization>. These three partners have elevated us this year and we're so grateful to have the ability to both serve them and rely on them as our new friends."
   },
   "page.year-in-review.2020.section.community-building.volunteers.heading": {
     "message": "Volunteers"
   },
+  "page.year-in-review.2020.section.community-building.volunteers.paragraph": {
+    "message": "This year we attracted volunteers that worked for <no-localization>Trello</no-localization>, <no-localization>Microsoft</no-localization>, <no-localization>Etsy</no-localization>, <no-localization>Better Eating</no-localization>, <no-localization>Mercy for Animals</no-localization>, <no-localization>Save Movement</no-localization> and <no-localization>Paypal</no-localization>!"
+  },
   "page.year-in-review.2020.section.header.image.alt-text": {
     "message": "2020 year in review"
   },
-  "page.year-in-review.2020.section.highlighted-projects.animal-rights-map.content": {
-    "message": "With over 2,500 groups, the Animal Rights Map is a globally updated map that helps vegans find local groups to get active with. Our map includes everyone from the largest organizations to the very small grassroots groups spread around the country. We worked with a few organizations to import new groups automatically, and we have a dedicated volunteer (that started this project) who meticulously updates the map almost every day. We've received a lot of great feedback for the map from vegans who were looking to get active - we plan on gathering more data soon and expanding the features of this map for 2021!"
+  "page.year-in-review.2020.section.highlighted-projects.animal-rights-map.paragraph": {
+    "message": "With over 2,500 groups, the <no-localization>Animal Rights Map</no-localization> is a globally updated map that helps vegans find local groups to get active with. Our map includes everyone from the largest organizations to the very small grassroots groups spread around the country. We worked with a few organizations to import new groups automatically, and we have a dedicated volunteer (that started this project) who meticulously updates the map almost every day. We've received a lot of great feedback for the map from vegans who were looking to get active - we plan on gathering more data soon and expanding the features of this map for 2021!"
   },
-  "page.year-in-review.2020.section.highlighted-projects.daily-nooch.content": {
-    "message": "With this project we wanted to create something a little more fun and light-weight that vegans could enjoy consuming and sharing with the world. Daily Nooch is your one-stop source for daily vegan news, resources and inspiration. Designed to be your homepage, get the latest news, quotes, art, memes, facts, videos, and more updated every day at midnight. This project is very experimental and we don't know if vegans will use this consistently, but in the meantime the team had a lot of fun building it. If folks like it we have a bunch of fun ideas to explore that will add more interactivity to the project."
+  "page.year-in-review.2020.section.highlighted-projects.daily-nooch.paragraph": {
+    "message": "With this project we wanted to create something a little more fun and light-weight that vegans could enjoy consuming and sharing with the world. <no-localization>Daily Nooch</no-localization> is your one-stop source for daily vegan news, resources and inspiration. Designed to be your homepage, get the latest news, quotes, art, memes, facts, videos, and more updated every day at midnight. This project is very experimental and we don't know if vegans will use this consistently, but in the meantime the team had a lot of fun building it. If folks like it we have a bunch of fun ideas to explore that will add more interactivity to the project."
   },
   "page.year-in-review.2020.section.highlighted-projects.heading": {
     "message": "See our HIGHLIGHTED PROJECTS"
   },
-  "page.year-in-review.2020.section.highlighted-projects.my-daily-dozen.content": {
-    "message": "Dr. Greger, founder of NutritionFacts.org, created an app called \"Daily Dozen\" that allows you to track your diet and make sure you get the best nutrition possible - and details the healthiest foods and how many servings of each we should try to check off every day. We wanted to expand on this concept and create a web-based version of his app with some additional features. Use My Daily Dozen to keep daily track of the foods recommended by Dr. Greger in his New York Times Bestselling book, How Not to Die. We hope that this project will give non-vegans the opportunity for an easier path to veganism by adopting a plant-based lifestyle."
+  "page.year-in-review.2020.section.highlighted-projects.my-daily-dozen.paragraph": {
+    "message": "<no-localization>Dr. Greger</no-localization>, founder of <no-localization>NutritionFacts.org</no-localization>, created an app called <no-localization>\"Daily Dozen\"</no-localization> that allows you to track your diet and make sure you get the best nutrition possible - and details the healthiest foods and how many servings of each we should try to check off every day. We wanted to expand on this concept and create a web-based version of his app with some additional features. Use My <no-localization>Daily Dozen</no-localization> to keep daily track of the foods recommended by <no-localization>Dr. Greger</no-localization> in his <no-localization>New York Times</no-localization> Bestselling book, <no-localization>How Not to Die</no-localization>. We hope that this project will give non-vegans the opportunity for an easier path to veganism by adopting a plant-based lifestyle."
   },
-  "page.year-in-review.2020.section.highlighted-projects.vegan-bootcamp.content": {
-    "message": "Following the success of Vegan Bootcamp's launch in 2019 with over 5000+ signups, we decided to invest more time in improving it. We sent out a survey to all members and received a large amount of feedback helping us decide what new content and features were needed. Vegan Bootcamp now includes community forums, individual courses, tags, better rewards, advanced statistics for referrals, content search, a vegan dietitian support program, a mentorship support program, and it now comes translated in 10 different languages!"
+  "page.year-in-review.2020.section.highlighted-projects.vegan-bootcamp.paragraph": {
+    "message": "Following the success of <no-localization>Vegan Bootcamp's</no-localization> launch in 2019 with over 5000+ signups, we decided to invest more time in improving it. We sent out a survey to all members and received a large amount of feedback helping us decide what new content and features were needed. <no-localization>Vegan Bootcamp</no-localization> now includes community forums, individual courses, tags, better rewards, advanced statistics for referrals, content search, a vegan dietitian support program, a mentorship support program, and it now comes translated in 10 different languages!"
   },
   "page.year-in-review.2020.section.moving-forward.btn.text": {
     "message": "Support our work!"
   },
-  "page.year-in-review.2020.section.moving-forward.content[0]": {
-    "message": "While we're happy with this years results as-well, we recognize the need to take a more data-based approach in what we build if we are to utilize our network of amazing volunteers effectively."
-  },
-  "page.year-in-review.2020.section.moving-forward.content[1]": {
-    "message": "We also recognize that innovation often comes in uncharted territories where data is often lacking - so for 2021 we want to find a good balance of choosing projects that align with our innovation approach, while utilizing data to pick which ones may have the greater chance of impact in our movement."
-  },
-  "page.year-in-review.2020.section.moving-forward.content[2]": {
-    "message": "We're really excited to hear your thoughts on our 2020 year in review, and if you like what we do, please consider supporting us by clicking the button below. Your donation ensures that all of our work and projects remain free and accessible to everyone, and we can't begin to thank you enough for the support!"
-  },
   "page.year-in-review.2020.section.moving-forward.heading": {
     "message": "Finishing up and moving forward!"
   },
-  "page.year-in-review.2020.section.new-teams.blueberry.content": {
-    "message": "We recently introduced the Specialists team! 9 new activists have joined the team and each one currently fulfilling the roles of: Release, DevOps, Security, SEO, CSS, Art, Maps, Video, and Audio. This filled a gap where our team members could specifically get issues addressed on their projects through Team Bluebbery."
+  "page.year-in-review.2020.section.moving-forward.paragraph.0": {
+    "message": "While we're happy with this years results as-well, we recognize the need to take a more data-based approach in what we build if we are to utilize our network of amazing volunteers effectively."
+  },
+  "page.year-in-review.2020.section.moving-forward.paragraph.1": {
+    "message": "We also recognize that innovation often comes in uncharted territories where data is often lacking - so for 2021 we want to find a good balance of choosing projects that align with our innovation approach, while utilizing data to pick which ones may have the greater chance of impact in our movement."
+  },
+  "page.year-in-review.2020.section.moving-forward.paragraph.2": {
+    "message": "We're really excited to hear your thoughts on our 2020 year in review, and if you like what we do, please consider supporting us by clicking the button below. Your donation ensures that all of our work and projects remain free and accessible to everyone, and we can't begin to thank you enough for the support!"
   },
   "page.year-in-review.2020.section.new-teams.blueberry.heading": {
     "message": "<span>Specialists</span> | Team Blueberry"
   },
-  "page.year-in-review.2020.section.new-teams.strawberry.content[0]": {
-    "message": "We've <link>started up a new team</link> dedicated to collecting and analyzing data not only on the projects that we build, but Vegan Hacktivists as an organization. This team marks our commitment to data, a commitment to making sure that everything we do makes a big impact, and that we're able to learn from our work in the past, as well as shaping the work we do in the future."
-  },
-  "page.year-in-review.2020.section.new-teams.strawberry.content[1]": {
-    "message": "Suan Chin is leading this team with 7 other data scientists. See the entire team by visiting the <link>team page here</link>. We're excited to see how this team will shape the future of the work we do!"
+  "page.year-in-review.2020.section.new-teams.blueberry.paragraph": {
+    "message": "We recently introduced the Specialists team! 9 new activists have joined the team and each one currently fulfilling the roles of: Release, DevOps, Security, <no-localization>SEO</no-localization>, <no-localization>CSS</no-localization>, Art, Maps, Video, and Audio. This filled a gap where our team members could specifically get issues addressed on their projects through Team Blueberry."
   },
   "page.year-in-review.2020.section.new-teams.strawberry.heading": {
     "message": "<span>Data Analytics</span> | Team Strawberry"
   },
-  "page.year-in-review.2020.section.strategy-and-experimentation.content[0]": {
-    "message": "Like 2019, we focused on building projects with little data on whether those projects would succeed. We consider this a high-risk strategy as we use hundreds of hours volunteer time on these experimental projects."
+  "page.year-in-review.2020.section.new-teams.strawberry.paragraph.0": {
+    "message": "We've <link>started up a new team</link> dedicated to collecting and analyzing data not only on the projects that we build, but <no-localization>Vegan Hacktivists</no-localization> as an organization. This team marks our commitment to data, a commitment to making sure that everything we do makes a big impact, and that we're able to learn from our work in the past, as well as shaping the work we do in the future."
   },
-  "page.year-in-review.2020.section.strategy-and-experimentation.content[1]": {
-    "message": "We're thankful this worked last year as 3 of the 6 projects we built met our standards of success, so we continued with this methodology. We firmly believe it's important for any movement to innovate, try new tactics, build experimental tools, and strategize alternatively."
+  "page.year-in-review.2020.section.new-teams.strawberry.paragraph.1": {
+    "message": "<no-localization>Suan Chin</no-localization> is leading this team with 7 other data scientists. See the entire team by visiting the <link>team page here</link>. We're excited to see how this team will shape the future of the work we do!"
   },
   "page.year-in-review.2020.section.strategy-and-experimentation.heading": {
     "message": "Strategy and experimentation"
   },
+  "page.year-in-review.2020.section.strategy-and-experimentation.paragraph.0": {
+    "message": "Like 2019, we focused on building projects with little data on whether those projects would succeed. We consider this a high-risk strategy as we use hundreds of hours volunteer time on these experimental projects."
+  },
+  "page.year-in-review.2020.section.strategy-and-experimentation.paragraph.1": {
+    "message": "We're thankful this worked last year as 3 of the 6 projects we built met our standards of success, so we continued with this methodology. We firmly believe it's important for any movement to innovate, try new tactics, build experimental tools, and strategize alternatively."
+  },
   "page.year-in-review.2020.section.we-grew.advisory-team.content": {
-    "message": "We're incredibly thankful to now have a team of experienced vegan advisors to lean on such as Seb Alex, Ryuji Chua, Leah Doellinger and Michael Dearborn. Browse more of our advisors, <link>click here!</link>"
-  },
-  "page.year-in-review.2020.section.we-grew.advisory-team.heading.bold": {
-    "message": "ADVISORY TEAM"
-  },
-  "page.year-in-review.2020.section.we-grew.advisory-team.heading.end": {
-    "message": "OF VEGAN EXPERTS"
-  },
-  "page.year-in-review.2020.section.we-grew.advisory-team.heading.start": {
-    "message": "WE NOW HAVE AN"
+    "message": "We're incredibly thankful to now have a team of experienced vegan advisors to lean on such as <no-localization>Seb Alex</no-localization>, <no-localization>Ryuji Chua</no-localization>, <no-localization>Leah Doellinger</no-localization> and <no-localization>Michael Dearborn</no-localization>. Browse more of our advisors, <link>click here!</link>"
   },
   "page.year-in-review.2020.section.we-grew.expanded.content": {
     "message": "We expanded from just 3 teams of 28 volunteers to 7 teams of 80 volunteers! We were able to open up more positions including content creators, animators, social, marketing, and advertising!"
-  },
-  "page.year-in-review.2020.section.we-grew.expanded.heading.bold": {
-    "message": "28 TO 80 VOLUNTEERS"
-  },
-  "page.year-in-review.2020.section.we-grew.expanded.heading.start": {
-    "message": "WE EXPANDED OUR TEAM FROM"
   },
   "page.year-in-review.2020.section.we-grew.heading": {
     "message": "We grew a lot as a community"
@@ -1113,43 +1098,34 @@
     "message": "This year, we worked with some amazing vegan organizations, helped a lot of people with their advocacy, and had a blast building interesting projects for the movement. Our team almost grew three fold and there were a lot of new challenges that came with that growth, but we're really happy with what we accomplished and we can't wait to see what 2021 brings for us!"
   },
   "page.year-in-review.2020.section.we-grew.launched.content": {
-    "message": "Four of which were unique project ideas of our own! We were also lucky enough to work on projects with Animal Rebellion, Animal Save Movement, Lebanese Vegans, and the Excelsior 4!"
-  },
-  "page.year-in-review.2020.section.we-grew.launched.heading.bold": {
-    "message": "EIGHT PROJECTS"
-  },
-  "page.year-in-review.2020.section.we-grew.launched.heading.end": {
-    "message": "FOR THE MOVEMENT"
-  },
-  "page.year-in-review.2020.section.we-grew.launched.heading.start": {
-    "message": "WE LAUNCHED"
-  },
-  "page.year-in-review.2020.section.working-with-organizations.animal-rebellion.content": {
-    "message": "We partnered with Animal Rebellion this year to help build their new website, which we dedicated an entire team for that took about 6 months of work. Their tech team were fantastic to work with, they were very knowledgeable and we felt like we were working with a team of professional during each encounter during our work. Animal Rebellion is a mass movement that uses nonviolent civil resistance to bring about a transition to a just and sustainable plant-based food system as an attempt to halt massive extinction, alleviate the worst effects of climate breakdown, and ensure justice for animals."
+    "message": "Four of which were unique project ideas of our own! We were also lucky enough to work on projects with <no-localization>Animal Rebellion</no-localization>, <no-localization>Animal Save Movement</no-localization>, <no-localization>Lebanese Vegans</no-localization>, and the <no-localization>Excelsior 4</no-localization>!"
   },
   "page.year-in-review.2020.section.working-with-organizations.animal-rebellion.heading": {
-    "message": "Animal Rebellion"
+    "message": "<no-localization>Animal Rebellion</no-localization>"
   },
-  "page.year-in-review.2020.section.working-with-organizations.animal-save-movement.content": {
-    "message": "We were able to work with Animal Save and help them with their new website. We also helped with their Ad campaign and managed those for a few months to help promote more of Save's work and newsletter. If you haven't heard of Save, their mission is to hold vigils at every slaughterhouse and to bear witness to every exploited animal. They also run the Climate and Health Save Movement, which promote reversing catastrophic climate change and making plant-based diets accessible. It was an absolute joy to meet and work with their team of passionate activists!"
+  "page.year-in-review.2020.section.working-with-organizations.animal-rebellion.paragraph": {
+    "message": "We partnered with <no-localization>Animal Rebellion</no-localization> this year to help build their new website, which we dedicated an entire team for that took about 6 months of work. Their tech team were fantastic to work with, they were very knowledgeable and we felt like we were working with a team of professional during each encounter during our work. <no-localization>Animal Rebellion</no-localization> is a mass movement that uses nonviolent civil resistance to bring about a transition to a just and sustainable plant-based food system as an attempt to halt massive extinction, alleviate the worst effects of climate breakdown, and ensure justice for animals."
   },
   "page.year-in-review.2020.section.working-with-organizations.animal-save-movement.heading": {
-    "message": "Animal Save Movement"
+    "message": "<no-localization>Animal Save Movement</no-localization>"
   },
-  "page.year-in-review.2020.section.working-with-organizations.excelsior.content": {
-    "message": "The Excelsior 4 are four activists are facing charges, with 21 counts in total after exposing criminal animal cruelty at Excelsior Hog Farm. We worked with them to get a new site launched that would allow them to fundraise their legal defense as fast as possible. We really think that the work they did and what they exposed is extremely important and we're so happy to have had the chance to support and help them get up and running. Please do check them out and support if you can!"
+  "page.year-in-review.2020.section.working-with-organizations.animal-save-movement.paragraph": {
+    "message": "We were able to work with <no-localization>Animal Save</no-localization> and help them with their new website. We also helped with their Ad campaign and managed those for a few months to help promote more of <no-localization>Save's</no-localization> work and newsletter. If you haven't heard of <no-localization>Save</no-localization>, their mission is to hold vigils at every slaughterhouse and to bear witness to every exploited animal. They also run the Climate and Health Save Movement, which promote reversing catastrophic climate change and making plant-based diets accessible. It was an absolute joy to meet and work with their team of passionate activists!"
   },
   "page.year-in-review.2020.section.working-with-organizations.excelsior.heading": {
-    "message": "The Excelsior 4"
+    "message": "<no-localization>The Excelsior 4</no-localization>"
+  },
+  "page.year-in-review.2020.section.working-with-organizations.excelsior.paragraph": {
+    "message": "The <no-localization>Excelsior 4</no-localization> are four activists are facing charges, with 21 counts in total after exposing criminal animal cruelty at <no-localization>Excelsior</no-localization> Hog Farm. We worked with them to get a new site launched that would allow them to fundraise their legal defense as fast as possible. We really think that the work they did and what they exposed is extremely important and we're so happy to have had the chance to support and help them get up and running. Please do check them out and support if you can!"
   },
   "page.year-in-review.2020.section.working-with-organizations.heading": {
     "message": "Working with ORGANIZATIONS"
   },
-  "page.year-in-review.2020.section.working-with-organizations.lebanese-vegans.content": {
-    "message": "The Lebanese Vegans social hub is the only animal rights and vegan support center in Southwest Asia and North Africa offering free monthly workshops and lectures about veganism, free weekly food distribution and monthly campaigns raising awareness about animal rights. We were lucky enough to work with them to help them both launch their new website and also re-branding with a new logo. We had a great time working through our advisor, Seb Alex, who organizes the work behind Lebanese Vegans."
-  },
   "page.year-in-review.2020.section.working-with-organizations.lebanese-vegans.heading": {
-    "message": "Lebanese Vegans"
+    "message": "<no-localization>Lebanese Vegans</no-localization>"
+  },
+  "page.year-in-review.2020.section.working-with-organizations.lebanese-vegans.paragraph": {
+    "message": "The <no-localization>Lebanese Vegans</no-localization> social hub is the only animal rights and vegan support center in Southwest Asia and North Africa offering free monthly workshops and lectures about veganism, free weekly food distribution and monthly campaigns raising awareness about animal rights. We were lucky enough to work with them to help them both launch their new website and also re-branding with a new logo. We had a great time working through our advisor, <no-localization>Seb Alex</no-localization>, who organizes the work behind <no-localization>Lebanese Vegans</no-localization>."
   },
   "page.year-in-review.2021.next-seo.title": {
     "message": "2021 in Review"

--- a/translation/data/en.json
+++ b/translation/data/en.json
@@ -879,7 +879,7 @@
     "message": "Advice"
   },
   "page.sign-in.already-signed-in.content": {
-    "message": "You are already logged in. No callbackUrl provided. <button>Go to Playground</button>"
+    "message": "You are already logged in. No <no-localization>callbackUrl</no-localization> provided. <button>Go to <no-localization>Playground</no-localization></button>"
   },
   "page.sign-in.button.sign-in": {
     "message": "Sign in!"

--- a/translation/data/en.json
+++ b/translation/data/en.json
@@ -305,13 +305,13 @@
   "page.grants.section.application.form.a.input.applicant-gender.label": {
     "message": "Gender <span>(optional)</span>"
   },
-  "page.grants.section.application.form.a.input.applicant-gender.option[0]": {
+  "page.grants.section.application.form.a.input.applicant-gender.option.0": {
     "message": "male"
   },
-  "page.grants.section.application.form.a.input.applicant-gender.option[1]": {
+  "page.grants.section.application.form.a.input.applicant-gender.option.1": {
     "message": "female"
   },
-  "page.grants.section.application.form.a.input.applicant-gender.option[2]": {
+  "page.grants.section.application.form.a.input.applicant-gender.option.2": {
     "message": "other"
   },
   "page.grants.section.application.form.a.input.applicant-gender.placeholder": {
@@ -387,13 +387,13 @@
     "message": "Please confirm your ability to accept funding"
   },
   "page.grants.section.application.form.c.input.can-accept-funding.text": {
-    "message": "I confirm that I have a bank or PayPal account that is in my name or my organization's name and that can receive grant payments in US Dollars. I confirm my understanding that - with the exception of my fiscal sponsor, if applicable - TPP is unable to make grant payments to any other person or entity on my behalf. I understand that if TPP reviews my proposal and decides to make an offer of funding, that offer is conditional on the ability to accept funds to an account in my name or in my organization's name."
+    "message": "I confirm that I have a bank or <no-localization>PayPal</no-localization> account that is in my name or my organization's name and that can receive grant payments in US Dollars. I confirm my understanding that - with the exception of my fiscal sponsor, if applicable - <no-localization>TPP</no-localization> is unable to make grant payments to any other person or entity on my behalf. I understand that if <no-localization>TPP</no-localization> reviews my proposal and decides to make an offer of funding, that offer is conditional on the ability to accept funds to an account in my name or in my organization's name."
   },
   "page.grants.section.application.form.c.input.funds-usage.label": {
     "message": "What will the funds be used for?"
   },
   "page.grants.section.application.form.c.input.funds-usage.text": {
-    "message": "Please list each budget item and the associated cost. The total should equal the total funding you are requesting from TPP. Example: <ul> <li>1 1lb bag of corn - $5</li> <li>3 Garden Shovels - $35</li> </ul>"
+    "message": "Please list each budget item and the associated cost. The total should equal the total funding you are requesting from <no-localization>TPP</no-localization>. Example: <ul> <li>1 1lb bag of corn - $5</li> <li>3 Garden Shovels - $35</li> </ul>"
   },
   "page.grants.section.application.form.c.input.total-budget.error": {
     "message": "Please enter a positive value"
@@ -405,7 +405,7 @@
     "message": "Please tell us the total cost of the project. This amount should include the expenditure for all activities associated with the project"
   },
   "page.grants.section.application.form.c.intro": {
-    "message": "<div> Your project's budget is a very important part of your application. Our team often uses this information to support their final decisions. Keep in mind that the budget items you list are ones that will serve to complete your proposed project, so be very specific in how the requested funding will be used. </div> <div> Please note, all information in this section should be given in <b>US Dollars</b> (US$). </div>"
+    "message": "<div>Your project's budget is a very important part of your application. Our team often uses this information to support their final decisions. Keep in mind that the budget items you list are ones that will serve to complete your proposed project, so be very specific in how the requested funding will be used.</div> <div>Please note, all information in this section should be given in <b>US Dollars</b> (US$).</div>"
   },
   "page.grants.section.application.form.message.error": {
     "message": "Something went wrong processing your submission! Please try again later"
@@ -428,23 +428,23 @@
   "page.grants.section.heading.text": {
     "message": "Seed Funding Grants"
   },
-  "page.grants.section.perks.check-ins.content": {
-    "message": "A monthly 30-minute Zoom call to help advise you and your team. Topics include but are not limited to technology, marketing, strategy, and other aspects of your organization's growth and development."
-  },
   "page.grants.section.perks.check-ins.heading": {
     "message": "Monthly Advisory Check-ins"
   },
-  "page.grants.section.perks.content-dev.content": {
-    "message": "We help craft any public-facing messages, including website copy. We offer our writing and editing skills at any stage of the process: from initial brainstorming to reviewing copy that helps promote your work."
+  "page.grants.section.perks.check-ins.paragraph": {
+    "message": "A monthly 30-minute <no-localization>Zoom</no-localization> call to help advise you and your team. Topics include but are not limited to technology, marketing, strategy, and other aspects of your organization's growth and development."
   },
   "page.grants.section.perks.content-dev.heading": {
     "message": "Content Development"
   },
-  "page.grants.section.perks.design-creation.content": {
-    "message": "Depending on your needs, we design (or redesign) the branding and logo for your organization or project. We also provide digital assets, such as banners, icons, and any custom elements, for social media and your website."
+  "page.grants.section.perks.content-dev.paragraph": {
+    "message": "We help craft any public-facing messages, including website copy. We offer our writing and editing skills at any stage of the process: from initial brainstorming to reviewing copy that helps promote your work."
   },
   "page.grants.section.perks.design-creation.heading": {
     "message": "Design Creation"
+  },
+  "page.grants.section.perks.design-creation.paragraph": {
+    "message": "Depending on your needs, we design (or redesign) the branding and logo for your organization or project. We also provide digital assets, such as banners, icons, and any custom elements, for social media and your website."
   },
   "page.grants.section.perks.heading": {
     "message": "Heart icon"
@@ -452,37 +452,37 @@
   "page.grants.section.perks.heading.image.alt-text": {
     "message": "In addition to seed funding, succesful applicants can receive:"
   },
-  "page.grants.section.perks.squarespace.content": {
+  "page.grants.section.perks.squarespace.heading": {
+    "message": "<no-localization>Squarespace</no-localization> Website Subscription"
+  },
+  "page.grants.section.perks.squarespace.paragraph": {
     "message": "<div>Valued at $200, we cover the subscription cost for the first year.</div> <div>You own it, and we help you design and maintain it.</div> <div>Easy to update with little to no experience.</div>"
   },
-  "page.grants.section.perks.squarespace.heading": {
-    "message": "Squarespace Website Subscription"
-  },
   "page.grants.section.pollination-project.button": {
-    "message": "ThePollinationProject.org"
-  },
-  "page.grants.section.pollination-project.content[0]": {
-    "message": "Our grants connection service is generously funded by The Pollination Project (TPP) and other private donors— please keep an eye out in your inbox, and don't forget to check spam!"
-  },
-  "page.grants.section.pollination-project.content[1]": {
-    "message": "If your primary focus does not address farmed animals, you may still be eligible for a grant directly from TPP. We encourage you to apply through their website."
+    "message": "<no-localization>ThePollinationProject.org</no-localization>"
   },
   "page.grants.section.pollination-project.image.alt-text": {
-    "message": "Logo of The Pollination Project"
+    "message": "Logo of <no-localization>The Pollination Project</no-localization>"
   },
-  "page.grants.section.qualifications.cta[0].content": {
+  "page.grants.section.pollination-project.paragraph.0": {
+    "message": "Our grants connection service is generously funded by <no-localization>The Pollination Project (TPP)</no-localization> and other private donors— please keep an eye out in your inbox, and don't forget to check spam!"
+  },
+  "page.grants.section.pollination-project.paragraph.1": {
+    "message": "If your primary focus does not address farmed animals, you may still be eligible for a grant directly from <no-localization>TPP</no-localization>. We encourage you to apply through their website."
+  },
+  "page.grants.section.qualifications.cta.paragraph.0": {
     "message": "<b>Don't meet the qualifications above?</b> You may still be eligible for funding! Apply and we'll forward your application to other potential funders."
   },
-  "page.grants.section.qualifications.cta[1].content": {
+  "page.grants.section.qualifications.cta.paragraph.1": {
     "message": "If you meet the qualifications, fill out the application form below."
   },
   "page.grants.section.qualifications.heading": {
     "message": "Before applying, make sure you meet these qualifications:"
   },
-  "page.grants.section.qualifications.step[0].content": {
+  "page.grants.section.qualifications.steps.paragraph.0": {
     "message": "<b> Your primary goal </b> should focus on reducing farmed animal suffering. Factory farming causes over 100 billion animals to suffer deprivation, fear, and pain every year."
   },
-  "page.grants.section.qualifications.step[1].content": {
+  "page.grants.section.qualifications.steps.paragraph.1": {
     "message": "<b> You must have </b> prior activism experience, whether in animal rights or other social movements. We're looking for people who have worked on and contributed to grassroots campaigns and/or projects, in a paid or volunteer capacity."
   },
   "page.grants.section.subheading": {

--- a/translation/data/en.json
+++ b/translation/data/en.json
@@ -740,13 +740,13 @@
   "page.people.section.advisors.community.image.alt-text": {
     "message": "Our community"
   },
-  "page.people.section.advisors.community.text": {
+  "page.people.section.advisors.community.paragraph": {
     "message": "We are more than a group of volunteers; we are a community tethered by shared values and invested in a vision of a better world for animals. We believe in a community-first approach: one that is supportive, growth-oriented, and accountable to each other. If this resonates with you, scroll down to learn more."
   },
   "page.people.section.advisors.intro.heading": {
     "message": "Our advisors"
   },
-  "page.people.section.advisors.intro.text": {
+  "page.people.section.advisors.intro.paragraph": {
     "message": "We are incredibly thankful for our team of experienced advisors who provide guidance and direction to the organization, its strategy, and projects."
   },
   "page.people.section.advisors.next-seo.title": {
@@ -770,13 +770,13 @@
   "page.people.section.partners.community.image.alt-text": {
     "message": "Our community"
   },
-  "page.people.section.partners.community.text": {
+  "page.people.section.partners.community.paragraph": {
     "message": "We are more than a group of volunteers; we are a community tethered by shared values and invested in a vision of a better world for animals. We believe in a community-first approach: one that is supportive, growth-oriented, and accountable to each other. If this resonates with you, scroll down to learn more."
   },
   "page.people.section.partners.intro.heading": {
     "message": "Our partners"
   },
-  "page.people.section.partners.intro.text": {
+  "page.people.section.partners.intro.paragraph": {
     "message": "Here are partner organizations that we support and are supported by. Take a look to learn more about the amazing work they do!"
   },
   "page.people.section.partners.next-seo.title": {
@@ -788,7 +788,7 @@
   "page.people.section.team.community.image.alt-text": {
     "message": "Our community"
   },
-  "page.people.section.team.community.text": {
+  "page.people.section.team.community.paragraph": {
     "message": "We are more than a group of volunteers; we are a community tethered by shared values and invested in a vision of a better world for animals. We believe in a community-first approach: one that is supportive, growth-oriented, and accountable to each other. If this resonates with you, scroll down to learn more."
   },
   "page.people.section.team.next-seo.title": {
@@ -803,13 +803,13 @@
   "page.people.section.volunteers.community.image.alt-text": {
     "message": "Our community"
   },
-  "page.people.section.volunteers.community.text": {
+  "page.people.section.volunteers.community.paragraph": {
     "message": "We are more than a group of volunteers; we are a community tethered by shared values and invested in a vision of a better world for animals. We believe in a community-first approach: one that is supportive, growth-oriented, and accountable to each other. If this resonates with you, scroll down to learn more."
   },
   "page.people.section.volunteers.intro.heading": {
     "message": "Our volunteers"
   },
-  "page.people.section.volunteers.intro.text": {
+  "page.people.section.volunteers.intro.paragraph": {
     "message": "Our volunteer community is at the heart of our organization, and enables us to build innovative projects and contribute to the movement in meaningful ways. <b>Click on an icon to meet the volunteers in each team!</b>"
   },
   "page.people.section.volunteers.next-seo.title": {

--- a/translation/data/en.json
+++ b/translation/data/en.json
@@ -101,58 +101,58 @@
   "page.about.section.our-mission.section-header.image.alt-text": {
     "message": "Our mission"
   },
-  "page.about.section.our-mission.subsection-1.content": {
+  "page.about.section.our-mission.subsection-0.heading": {
+    "message": "1. We need more data in our movement."
+  },
+  "page.about.section.our-mission.subsection-0.paragraph": {
     "message": "To determine effectiveness in projects, campaigns, and our work as a whole, meaningful data needs to be tracked and collected. We strongly believe that a data-driven movement will accelerate and elevate our work, which is why we prioritize identifying, gathering, and analyzing data, as well as making it accessible to others."
   },
   "page.about.section.our-mission.subsection-1.heading": {
-    "message": "1. We need more data in our movement."
+    "message": "2. We need more competition, too."
   },
-  "page.about.section.our-mission.subsection-2.content": {
+  "page.about.section.our-mission.subsection-1.paragraph": {
     "message": "We strongly believe competition is not only healthy but vital in improving our movement's effectiveness. Competition applies healthy pressure on organizations and projects to keep improving and iterating – and this gives us more information on what works."
   },
   "page.about.section.our-mission.subsection-2.heading": {
-    "message": "2. We need more competition, too."
+    "message": "3. We need to be more innovative."
   },
-  "page.about.section.our-mission.subsection-3.content": {
+  "page.about.section.our-mission.subsection-2.paragraph": {
     "message": "We believe the movement has the potential to be more innovative in its approaches. We promote outside-the-box thinking and make innovation a core consideration of every part of our work and our processes."
   },
   "page.about.section.our-mission.subsection-3.heading": {
-    "message": "3. We need to be more innovative."
+    "message": "4. And we need to start collaborating."
   },
-  "page.about.section.our-mission.subsection-4.content": {
+  "page.about.section.our-mission.subsection-3.paragraph": {
     "message": "We aim to help organizations and individuals connect and collaborate in more meaningful ways. We need to leverage our knowledge and network with each other to support our shared goals, whether that means sharing research or data, resources, or generally supporting each other overcome organizational challenges."
   },
   "page.about.section.our-mission.subsection-4.heading": {
-    "message": "4. And we need to start collaborating."
+    "message": "5. Finally, we need more vegans to become active."
   },
-  "page.about.section.our-mission.subsection-5.content": {
+  "page.about.section.our-mission.subsection-4.paragraph": {
     "message": "Only a tiny percentage of the world is vegan, and a fraction within are active. Many organizations encourage non-vegans to adopt veganism through health, environmental, or ethical reasons. We believe that we can also be effective by creating tools to help, inspire, and motivate more vegans to become advocates for the animals."
   },
-  "page.about.section.our-mission.subsection-5.heading": {
-    "message": "5. Finally, we need more vegans to become active."
+  "page.about.section.our-story.image.alt-text": {
+    "message": "Our story"
+  },
+  "page.about.section.our-story.intro.heading": {
+    "message": "Our story"
+  },
+  "page.about.section.our-story.intro.paragraph": {
+    "message": "In 2019, we launched our first project with a few volunteers who were passionate about activism. We’ve since grown into a community of highly-skilled and professional software engineers, designers, data scientists, and content creators supporting the movement. We started with the hopes of catalyzing people to action and inspiring them to become advocates for animals — and we are committed to this founding principle. Our digital skills fuel our activism."
   },
   "page.about.section.our-story.next-seo.title": {
     "message": "Our Story"
   },
-  "page.about.section.our-story.section-header.content": {
-    "message": "In 2019, we launched our first project with a few volunteers who were passionate about activism. We’ve since grown into a community of highly-skilled and professional software engineers, designers, data scientists, and content creators supporting the movement. We started with the hopes of catalyzing people to action and inspiring them to become advocates for animals — and we are committed to this founding principle. Our digital skills fuel our activism."
+  "page.about.section.our-story.paragraph.0": {
+    "message": "We are the <no-localization>Vegan Hacktivists</no-localization>. Our skill sets — whether it’s writing code, creating a brand identity, or analyzing data — are as diverse as the areas where we come from and where we live. We collaborate with each other to build projects that are data-driven, experimental, and effective. Our core team consists of director and senior-level team members who have experience and expertise in engineering, architecture, design, data, operations, and communications. Our volunteer base consists of teams managed by leads; each team has ownership of a project in which they are actively building and maintaining."
   },
-  "page.about.section.our-story.section-header.heading": {
-    "message": "Our story"
-  },
-  "page.about.section.our-story.section-header.image.alt-text": {
-    "message": "Our story"
-  },
-  "page.about.section.our-story.subsection-1.content": {
-    "message": "We are the Vegan Hacktivists. Our skill sets — whether it’s writing code, creating a brand identity, or analyzing data — are as diverse as the areas where we come from and where we live. We collaborate with each other to build projects that are data-driven, experimental, and effective. Our core team consists of director and senior-level team members who have experience and expertise in engineering, architecture, design, data, operations, and communications. Our volunteer base consists of teams managed by leads; each team has ownership of a project in which they are actively building and maintaining."
-  },
-  "page.about.section.our-story.subsection-2.content": {
+  "page.about.section.our-story.paragraph.1": {
     "message": "Our organization takes a community-first approach. Given that our work requires patience and commitment, we energize our volunteers by creating a supportive environment that enables them to be engaged, effective, and impactful. As a distributed organization, we want to build a sense of community aligned by values and connected through meaningful and playful interactions. Each team is represented with a <link>fruit or vegetable</link> (taking plant-based to another level), and we balance our work with games, get-togethers, and community calls. Our volunteers are, after all, at the heart of our organization."
   },
-  "page.about.section.our-story.subsection-3.content": {
+  "page.about.section.our-story.paragraph.2": {
     "message": "Over the years, our organization has changed with the needs of our movement. While we now primarily focus on providing capacity-building services, we continue to build technology that we believe to be innovative and highly needed in the movement. Now, we work extensively with advocates, organizations, and those working at the frontlines to help improve their day-to-day operations, brand and identity, and technology. In doing so, we are helping to amplify their message and elevate their work to a wider audience."
   },
-  "page.about.section.our-story.subsection-4.content": {
+  "page.about.section.our-story.paragraph.3": {
     "message": "Through it all, our North Star remains the same: <no-localization>{break}</no-localization> we do it for the animals."
   },
   "page.about.section.our-values.next-seo.title": {
@@ -167,41 +167,41 @@
   "page.about.section.our-values.section-header.image.alt-text": {
     "message": "Our values"
   },
-  "page.about.section.our-values.subsection-1.content": {
+  "page.about.section.our-values.subsection-0.heading": {
+    "message": "Animal Liberation"
+  },
+  "page.about.section.our-values.subsection-0.paragraph": {
     "message": "We value and respect the lives of all animals and denounce all forms of violence and exploitation against them. We believe animals have the right to be free, and we fight for that with our (digital) activism."
   },
   "page.about.section.our-values.subsection-1.heading": {
-    "message": "Animal Liberation"
+    "message": "Non-violence"
   },
-  "page.about.section.our-values.subsection-2.content": {
+  "page.about.section.our-values.subsection-1.paragraph": {
     "message": "We practice a love-based, community-first organizational approach. We exercise empathy, compassion, and non-violence. We encourage every member to communicate openly and kindly with each other."
   },
   "page.about.section.our-values.subsection-2.heading": {
-    "message": "Non-violence"
+    "message": "Safe Community"
   },
-  "page.about.section.our-values.subsection-3.content": {
+  "page.about.section.our-values.subsection-2.paragraph": {
     "message": "We believe in building and fostering safe and inclusive communities regardless of race, gender, species, age, sexual orientation, or political affiliation. We strive to be diverse and representative of the communities we serve and work with."
   },
   "page.about.section.our-values.subsection-3.heading": {
-    "message": "Safe Community"
+    "message": "Farmed Animals"
   },
-  "page.about.section.our-values.subsection-4.content": {
+  "page.about.section.our-values.subsection-3.paragraph": {
     "message": "We believe farmed animals are in most need of our support, which is why we focus primarily on farmed animal liberation as an organization."
   },
   "page.about.section.our-values.subsection-4.heading": {
-    "message": "Farmed Animals"
+    "message": "Open Feedback"
   },
-  "page.about.section.our-values.subsection-5.content": {
+  "page.about.section.our-values.subsection-4.paragraph": {
     "message": "We value different viewpoints and constructive feedback from every person. We believe everyone has something of value to contribute to the discussion. We always listen first, then respond constructively."
   },
   "page.about.section.our-values.subsection-5.heading": {
-    "message": "Open Feedback"
-  },
-  "page.about.section.our-values.subsection-6.content": {
-    "message": "We do not support or enable the exploitation or oppression of any group. We believe that the oppression of humans and non-human animals are interlinked, and the work to eradicate all forms of oppression is necessary."
-  },
-  "page.about.section.our-values.subsection-6.heading": {
     "message": "Anti-Oppression"
+  },
+  "page.about.section.our-values.subsection-5.paragraph": {
+    "message": "We do not support or enable the exploitation or oppression of any group. We believe that the oppression of humans and non-human animals are interlinked, and the work to eradicate all forms of oppression is necessary."
   },
   "page.blog.next-seo.title": {
     "message": "Blog"

--- a/translation/data/zh.json
+++ b/translation/data/zh.json
@@ -305,13 +305,13 @@
   "page.grants.section.application.form.a.input.applicant-gender.label": {
     "message": "性别<span>（可选）</span>"
   },
-  "page.grants.section.application.form.a.input.applicant-gender.option[0]": {
+  "page.grants.section.application.form.a.input.applicant-gender.option.0": {
     "message": "雄性"
   },
-  "page.grants.section.application.form.a.input.applicant-gender.option[1]": {
+  "page.grants.section.application.form.a.input.applicant-gender.option.1": {
     "message": "女性"
   },
-  "page.grants.section.application.form.a.input.applicant-gender.option[2]": {
+  "page.grants.section.application.form.a.input.applicant-gender.option.2": {
     "message": "其他"
   },
   "page.grants.section.application.form.a.input.applicant-gender.placeholder": {
@@ -428,19 +428,19 @@
   "page.grants.section.heading.text": {
     "message": "种子基金赠款"
   },
-  "page.grants.section.perks.check-ins.content": {
+  "page.grants.section.perks.check-ins.paragraph": {
     "message": "每月一次 30 分钟的 Zoom 电话会议，为您和您的团队提供建议。主题包括但不限于技术、营销、战略以及组织成长和发展的其他方面。"
   },
   "page.grants.section.perks.check-ins.heading": {
     "message": "每月咨询检查"
   },
-  "page.grants.section.perks.content-dev.content": {
+  "page.grants.section.perks.content-dev.paragraph": {
     "message": "我们帮助制作任何面向公众的信息，包括网站文案。从最初的头脑风暴到审查有助于宣传您作品的文案，我们都能在任何阶段提供写作和编辑技能。"
   },
   "page.grants.section.perks.content-dev.heading": {
     "message": "内容开发"
   },
-  "page.grants.section.perks.design-creation.content": {
+  "page.grants.section.perks.design-creation.paragraph": {
     "message": "根据您的需求，我们为您的组织或项目设计（或重新设计）品牌和徽标。我们还为您的社交媒体和网站提供数字资产，如横幅、图标和任何定制元素。"
   },
   "page.grants.section.perks.design-creation.heading": {
@@ -452,7 +452,7 @@
   "page.grants.section.perks.heading.image.alt-text": {
     "message": "除种子基金外，成功的申请者还可获得"
   },
-  "page.grants.section.perks.squarespace.content": {
+  "page.grants.section.perks.squarespace.paragraph": {
     "message": "<div>价值 200 美元，我们承担第一年的订阅费用。</div> <div>您拥有它，我们帮助您设计和维护它。</div> <div>无需经验，即可轻松更新。</div>"
   },
   "page.grants.section.perks.squarespace.heading": {
@@ -461,28 +461,28 @@
   "page.grants.section.pollination-project.button": {
     "message": "ThePollinationProject.org"
   },
-  "page.grants.section.pollination-project.content[0]": {
+  "page.grants.section.pollination-project.paragraph.0": {
     "message": "我们的赠款连接服务得到了授粉项目 (TPP) 和其他私人捐助者的慷慨资助--请留意您的收件箱，别忘了检查垃圾邮件！"
   },
-  "page.grants.section.pollination-project.content[1]": {
+  "page.grants.section.pollination-project.paragraph.1": {
     "message": "如果您的主要关注点不涉及养殖动物，您仍有资格直接获得 TPP 的资助。我们鼓励您通过其网站进行申请。"
   },
   "page.grants.section.pollination-project.image.alt-text": {
     "message": "授粉项目徽标"
   },
-  "page.grants.section.qualifications.cta[0].content": {
+  "page.grants.section.qualifications.cta.paragraph.0": {
     "message": "<b>不符合上述条件？</b>您仍然有资格获得资助！请提出申请，我们会将您的申请转发给其他潜在资助者。"
   },
-  "page.grants.section.qualifications.cta[1].content": {
+  "page.grants.section.qualifications.cta.paragraph.1": {
     "message": "如果您符合条件，请填写下面的申请表。"
   },
   "page.grants.section.qualifications.heading": {
     "message": "申请前，请确保您符合这些条件："
   },
-  "page.grants.section.qualifications.step[0].content": {
+  "page.grants.section.qualifications.steps.paragraph.0": {
     "message": "<b> 您的首要目标 </b>应该是减少养殖动物的痛苦。工厂化养殖每年导致超过 1000 亿只动物遭受剥夺、恐惧和痛苦。"
   },
-  "page.grants.section.qualifications.step[1].content": {
+  "page.grants.section.qualifications.steps.paragraph.1": {
     "message": "<b> 您必须 </b>在动物权利或其他社会运动方面有过活动经验。我们正在寻找曾以有偿或志愿者身份参与基层运动和/或项目并做出贡献的人员。"
   },
   "page.grants.section.subheading": {

--- a/translation/data/zh.json
+++ b/translation/data/zh.json
@@ -740,13 +740,13 @@
   "page.people.section.advisors.community.image.alt-text": {
     "message": "我们的社区"
   },
-  "page.people.section.advisors.community.text": {
+  "page.people.section.advisors.community.paragraph": {
     "message": "我们不仅仅是一群志愿者；我们是一个由共同价值观维系的社区，致力于为动物创造一个更美好的世界。我们坚信 \"社区第一 \"的理念：相互支持、共同成长、相互负责。如果您对此有共鸣，请向下滚动以了解更多信息。"
   },
   "page.people.section.advisors.intro.heading": {
     "message": "我们的顾问"
   },
-  "page.people.section.advisors.intro.text": {
+  "page.people.section.advisors.intro.paragraph": {
     "message": "我们非常感谢我们经验丰富的顾问团队，他们为组织、组织战略和项目提供了指导和方向。"
   },
   "page.people.section.advisors.next-seo.title": {
@@ -770,13 +770,13 @@
   "page.people.section.partners.community.image.alt-text": {
     "message": "我们的社区"
   },
-  "page.people.section.partners.community.text": {
+  "page.people.section.partners.community.paragraph": {
     "message": "我们不仅仅是一群志愿者；我们是一个由共同价值观维系的社区，致力于为动物创造一个更美好的世界。我们坚信 \"社区第一 \"的理念：相互支持、共同成长、相互负责。如果您对此有共鸣，请向下滚动以了解更多信息。"
   },
   "page.people.section.partners.intro.heading": {
     "message": "我们的合作伙伴"
   },
-  "page.people.section.partners.intro.text": {
+  "page.people.section.partners.intro.paragraph": {
     "message": "以下是我们支持的伙伴组织。请看一看，进一步了解他们所做的了不起的工作！"
   },
   "page.people.section.partners.next-seo.title": {
@@ -788,7 +788,7 @@
   "page.people.section.team.community.image.alt-text": {
     "message": "我们的社区"
   },
-  "page.people.section.team.community.text": {
+  "page.people.section.team.community.paragraph": {
     "message": "我们不仅仅是一群志愿者；我们是一个由共同价值观维系的社区，致力于为动物创造一个更美好的世界。我们坚信 \"社区第一 \"的理念：相互支持、共同成长、相互负责。如果您对此有共鸣，请向下滚动以了解更多信息。"
   },
   "page.people.section.team.next-seo.title": {
@@ -803,13 +803,13 @@
   "page.people.section.volunteers.community.image.alt-text": {
     "message": "我们的社区"
   },
-  "page.people.section.volunteers.community.text": {
+  "page.people.section.volunteers.community.paragraph": {
     "message": "我们不仅仅是一群志愿者；我们是一个由共同价值观维系的社区，致力于为动物创造一个更美好的世界。我们坚信 \"社区第一 \"的理念：相互支持、共同成长、相互负责。如果您对此有共鸣，请向下滚动以了解更多信息。"
   },
   "page.people.section.volunteers.intro.heading": {
     "message": "我们的志愿者"
   },
-  "page.people.section.volunteers.intro.text": {
+  "page.people.section.volunteers.intro.paragraph": {
     "message": "我们的志愿者社区是我们组织的核心，使我们能够建立创新项目，并以有意义的方式为运动做出贡献。<b>点击图标，了解每个团队的志愿者！</b>"
   },
   "page.people.section.volunteers.next-seo.title": {

--- a/translation/data/zh.json
+++ b/translation/data/zh.json
@@ -941,31 +941,31 @@
   "page.work.next-seo.title": {
     "message": "我们的工作"
   },
-  "page.year-in-review.2020.section.big-impact-changes.apple.content": {
+  "page.year-in-review.2020.section.big-impact-changes.apple.paragraph": {
     "message": "我们启用了社区活动和行动的机器人通知功能。"
   },
-  "page.year-in-review.2020.section.big-impact-changes.banana.content": {
+  "page.year-in-review.2020.section.big-impact-changes.banana.paragraph": {
     "message": "我们为志愿者开通了 LinkedIn 页面。"
   },
-  "page.year-in-review.2020.section.big-impact-changes.carrot.content": {
+  "page.year-in-review.2020.section.big-impact-changes.carrot.paragraph": {
     "message": "我们改进了入职流程和开发人员指南。"
   },
-  "page.year-in-review.2020.section.big-impact-changes.grape.content": {
+  "page.year-in-review.2020.section.big-impact-changes.grape.paragraph": {
     "message": "我们将 Google Analytics 集成到所有项目中。"
   },
   "page.year-in-review.2020.section.big-impact-changes.heading": {
     "message": "影响巨大的微小变化"
   },
-  "page.year-in-review.2020.section.big-impact-changes.kiwi.content": {
+  "page.year-in-review.2020.section.big-impact-changes.kiwi.paragraph": {
     "message": "我们发布并开源了过去的几个项目。"
   },
-  "page.year-in-review.2020.section.big-impact-changes.orange.content": {
+  "page.year-in-review.2020.section.big-impact-changes.orange.paragraph": {
     "message": "我们公布了匿名志愿者反馈表。"
   },
-  "page.year-in-review.2020.section.big-impact-changes.strawberry.content": {
+  "page.year-in-review.2020.section.big-impact-changes.strawberry.paragraph": {
     "message": "我们安装了先进的服务器监控软件。"
   },
-  "page.year-in-review.2020.section.big-impact-changes.watermelon.content": {
+  "page.year-in-review.2020.section.big-impact-changes.watermelon.paragraph": {
     "message": "我们开始接受 Python 开发人员的申请。"
   },
   "page.year-in-review.2020.section.by-the-numbers.2020-traffic.heading": {
@@ -1010,19 +1010,19 @@
   "page.year-in-review.2020.section.community-building.heading": {
     "message": "社区建设"
   },
-  "page.year-in-review.2020.section.community-building.our-values.content": {
+  "page.year-in-review.2020.section.community-building.our-values.paragraph": {
     "message": "我们作为一个社区走到了一起，决定了我们想要采纳的价值观，并正式确定了我们的使命和目标。"
   },
   "page.year-in-review.2020.section.community-building.our-values.heading": {
     "message": "我们的价值观"
   },
-  "page.year-in-review.2020.section.community-building.partnerships.content": {
+  "page.year-in-review.2020.section.community-building.partnerships.paragraph": {
     "message": "今年，我们非常高兴能与 PETA、Beyond Animal 和 Project Counterglow 合作。这三个合作伙伴在今年提升了我们的地位，我们非常感谢能够为他们服务，并将他们视为我们的新朋友。"
   },
   "page.year-in-review.2020.section.community-building.partnerships.heading": {
     "message": "合作伙伴"
   },
-  "page.year-in-review.2020.section.community-building.volunteers.content": {
+  "page.year-in-review.2020.section.community-building.volunteers.paragraph": {
     "message": "今年，我们吸引了为 Trello、微软、Etsy、Better Eating、Mercy for Animals、Save Movement 和 Paypal 工作的志愿者！"
   },
   "page.year-in-review.2020.section.community-building.volunteers.heading": {
@@ -1031,55 +1031,55 @@
   "page.year-in-review.2020.section.header.image.alt-text": {
     "message": "2020 年回顾"
   },
-  "page.year-in-review.2020.section.highlighted-projects.animal-rights-map.content": {
+  "page.year-in-review.2020.section.highlighted-projects.animal-rights-map.paragraph": {
     "message": "动物权利地图 \"拥有 2,500 多个团体，是一份全球更新的地图，可帮助素食主义者找到当地团体，积极参与其中。我们的地图涵盖了从最大的组织到遍布全国的小型草根团体的方方面面。我们与一些组织合作，自动导入新的团体，我们还有一名专门的志愿者（发起了这个项目），几乎每天都一丝不苟地更新地图。我们收到了很多希望积极参与活动的素食主义者对地图的反馈--我们计划很快收集更多数据，并在 2021 年扩大地图的功能！"
   },
-  "page.year-in-review.2020.section.highlighted-projects.daily-nooch.content": {
+  "page.year-in-review.2020.section.highlighted-projects.daily-nooch.paragraph": {
     "message": "在这个项目中，我们希望创造一些更有趣、更轻便的东西，让素食主义者能够享受消费并与世界分享。Daily Nooch 是您获取每日素食新闻、资源和灵感的一站式来源。该网站旨在成为您的主页，每天午夜更新最新的新闻、语录、艺术、备忘录、事实、视频等内容。这个项目非常具有实验性，我们不知道素食主义者是否会一直使用它，但与此同时，团队在创建它的过程中获得了很多乐趣。如果大家喜欢，我们还有很多有趣的想法可以探索，为项目增加更多的互动性。"
   },
   "page.year-in-review.2020.section.highlighted-projects.heading": {
     "message": "查看我们的重点项目"
   },
-  "page.year-in-review.2020.section.highlighted-projects.my-daily-dozen.content": {
+  "page.year-in-review.2020.section.highlighted-projects.my-daily-dozen.paragraph": {
     "message": "NutritionFacts.org 的创始人 Greger 博士创建了一个名为 \"每日一打 \"的应用程序，让您可以跟踪自己的饮食，确保获得尽可能多的营养，并详细介绍了最健康的食物以及我们每天应该尝试勾选的每种食物的份量。我们希望扩展这一概念，创建一个网络版的应用程序，并增加一些功能。使用 \"我的每日一打\"，您可以每天记录 Greger 博士在《纽约时报》畅销书《如何不死》中推荐的食物。我们希望这个项目能让非素食者有机会通过采用以植物为基础的生活方式更容易地成为素食者。"
   },
-  "page.year-in-review.2020.section.highlighted-projects.vegan-bootcamp.content": {
+  "page.year-in-review.2020.section.highlighted-projects.vegan-bootcamp.paragraph": {
     "message": "继 2019 年 Vegan Bootcamp 成功推出并获得 5000 多人注册后，我们决定投入更多时间对其进行改进。我们向所有会员发出了调查问卷，收到了大量反馈，帮助我们决定需要哪些新内容和新功能。现在，Vegan Bootcamp 包括社区论坛、个人课程、标签、更好的奖励、推荐人高级统计、内容搜索、素食营养师支持计划、导师支持计划，现在还翻译成 10 种不同的语言！"
   },
   "page.year-in-review.2020.section.moving-forward.btn.text": {
     "message": "支持我们的工作"
   },
-  "page.year-in-review.2020.section.moving-forward.content[0]": {
+  "page.year-in-review.2020.section.moving-forward.paragraph.0": {
     "message": "虽然我们对今年的结果也很满意，但我们认识到，如果要有效利用我们的优秀志愿者网络，我们就需要在建设过程中采取更加基于数据的方法。"
   },
-  "page.year-in-review.2020.section.moving-forward.content[1]": {
+  "page.year-in-review.2020.section.moving-forward.paragraph.1": {
     "message": "我们还认识到，创新往往是在缺乏数据的未知领域进行的，因此，对于 2021 年，我们希望在选择符合我们创新方法的项目时找到一个良好的平衡点，同时利用数据来选择哪些项目可能对我们的运动产生更大的影响。"
   },
-  "page.year-in-review.2020.section.moving-forward.content[2]": {
+  "page.year-in-review.2020.section.moving-forward.paragraph.2": {
     "message": "如果您喜欢我们的工作，请点击下面的按钮支持我们。您的捐款将确保我们的所有工作和项目对所有人免费开放，我们对您的支持感激不尽！"
   },
   "page.year-in-review.2020.section.moving-forward.heading": {
     "message": "收尾和前进"
   },
-  "page.year-in-review.2020.section.new-teams.blueberry.content": {
+  "page.year-in-review.2020.section.new-teams.blueberry.paragraph": {
     "message": "我们最近推出了专家团队！9 名新的积极分子加入了团队，他们目前分别担任以下角色：发布、开发运营、安全、搜索引擎优化、CSS、艺术、地图、视频和音频。这填补了我们的空白，使我们的团队成员可以通过 Bluebbery 团队专门解决他们项目中的问题。"
   },
   "page.year-in-review.2020.section.new-teams.blueberry.heading": {
     "message": "<span>专家</span>| 蓝莓团队"
   },
-  "page.year-in-review.2020.section.new-teams.strawberry.content[0]": {
+  "page.year-in-review.2020.section.new-teams.strawberry.paragraph.0": {
     "message": "我们<link>成立了一个新团队</link>，专门负责收集和分析数据，不仅是关于我们构建的项目，也是关于 Vegan Hacktivists 这个组织。这个团队标志着我们对数据的承诺，也是确保我们所做的每一件事都能产生巨大影响的承诺，同时也是我们能够从过去的工作中吸取经验教训，并塑造未来工作的承诺。"
   },
-  "page.year-in-review.2020.section.new-teams.strawberry.content[1]": {
+  "page.year-in-review.2020.section.new-teams.strawberry.paragraph.1": {
     "message": "Suan Chin 与其他 7 位数据科学家共同领导着这个团队。请访问<link>团队页面</link>查看整个团队。我们很高兴看到这个团队将如何塑造我们工作的未来！"
   },
   "page.year-in-review.2020.section.new-teams.strawberry.heading": {
     "message": "<span>数据分析</span>| 草莓团队"
   },
-  "page.year-in-review.2020.section.strategy-and-experimentation.content[0]": {
+  "page.year-in-review.2020.section.strategy-and-experimentation.paragraph.0": {
     "message": "与 2019 年一样，我们专注于建设项目，但对这些项目是否会成功几乎没有数据。我们认为这是一项高风险战略，因为我们在这些实验项目上花费了数百小时的志愿者时间。"
   },
-  "page.year-in-review.2020.section.strategy-and-experimentation.content[1]": {
+  "page.year-in-review.2020.section.strategy-and-experimentation.paragraph.1": {
     "message": "去年，我们建立的 6 个项目中有 3 个达到了我们的成功标准，因此我们继续采用这种方法。我们坚信，对于任何运动来说，创新、尝试新战术、建立实验性工具和制定替代战略都是非常重要的。"
   },
   "page.year-in-review.2020.section.strategy-and-experimentation.heading": {
@@ -1124,19 +1124,19 @@
   "page.year-in-review.2020.section.we-grew.launched.heading.start": {
     "message": "我们启动"
   },
-  "page.year-in-review.2020.section.working-with-organizations.animal-rebellion.content": {
+  "page.year-in-review.2020.section.working-with-organizations.animal-rebellion.paragraph": {
     "message": "今年，我们与 Animal Rebellion 合作，帮助他们建立了新网站，我们为此专门组建了一个团队，耗时约 6 个月。与他们的技术团队合作非常愉快，他们知识渊博，在工作中的每一次接触都让我们感觉是在与专业团队合作。动物叛乱 \"是一场群众运动，它通过非暴力的公民抵抗，实现向公正、可持续的植物性食物系统的过渡，试图阻止大规模的物种灭绝，减轻气候破坏带来的最坏影响，并确保为动物伸张正义。"
   },
   "page.year-in-review.2020.section.working-with-organizations.animal-rebellion.heading": {
     "message": "动物的反叛"
   },
-  "page.year-in-review.2020.section.working-with-organizations.animal-save-movement.content": {
+  "page.year-in-review.2020.section.working-with-organizations.animal-save-movement.paragraph": {
     "message": "我们与动物救助组织合作，帮助他们建立了新网站。我们还为他们的广告活动提供了帮助，并管理了几个月的广告活动，以帮助宣传更多 \"拯救 \"组织的工作和通讯。如果您还没有听说过 \"拯救 \"组织，他们的使命是在每一个屠宰场守夜，为每一只受剥削的动物作证。他们还发起了 \"拯救气候与健康运动\"，旨在推动扭转灾难性的气候变化，让人们能够吃上以植物为基础的饮食。能与他们这支充满热情的活动家团队会面和合作，我感到非常高兴！"
   },
   "page.year-in-review.2020.section.working-with-organizations.animal-save-movement.heading": {
     "message": "拯救动物运动"
   },
-  "page.year-in-review.2020.section.working-with-organizations.excelsior.content": {
+  "page.year-in-review.2020.section.working-with-organizations.excelsior.paragraph": {
     "message": "Excelsior 4 是四名积极分子，他们因揭露 Excelsior 养猪场虐待动物的犯罪行为而面临共计 21 项指控。我们与他们合作推出了一个新网站，使他们能够尽快筹集法律辩护资金。我们真的认为他们所做的工作和揭露的问题非常重要，我们很高兴能有机会支持并帮助他们启动和运行网站。如果可以，请一定去看看他们，并给予支持！"
   },
   "page.year-in-review.2020.section.working-with-organizations.excelsior.heading": {
@@ -1145,7 +1145,7 @@
   "page.year-in-review.2020.section.working-with-organizations.heading": {
     "message": "与组织合作"
   },
-  "page.year-in-review.2020.section.working-with-organizations.lebanese-vegans.content": {
+  "page.year-in-review.2020.section.working-with-organizations.lebanese-vegans.paragraph": {
     "message": "黎巴嫩素食者社会中心是西南亚和北非地区唯一的动物权利和素食者支持中心，每月举办免费的素食主义研讨会和讲座，每周免费发放食品，每月开展提高动物权利意识的活动。我们有幸与他们合作，帮助他们推出了新网站，并使用新徽标重塑了品牌形象。通过我们的顾问 Seb Alex（黎巴嫩素食者协会的幕后组织者），我们度过了一段愉快的合作时光。"
   },
   "page.year-in-review.2020.section.working-with-organizations.lebanese-vegans.heading": {

--- a/translation/data/zh.json
+++ b/translation/data/zh.json
@@ -101,58 +101,58 @@
   "page.about.section.our-mission.section-header.image.alt-text": {
     "message": "我们的使命"
   },
-  "page.about.section.our-mission.subsection-1.content": {
+  "page.about.section.our-mission.subsection-0.paragraph": {
     "message": "为了确定项目、活动和我们整体工作的有效性，需要跟踪和收集有意义的数据。我们坚信，数据驱动的运动将加速和提升我们的工作，这就是为什么我们优先考虑识别、收集和分析数据，并将其提供给他人。"
   },
-  "page.about.section.our-mission.subsection-1.heading": {
+  "page.about.section.our-mission.subsection-0.heading": {
     "message": "1.我们的运动需要更多的数据。"
   },
-  "page.about.section.our-mission.subsection-2.content": {
+  "page.about.section.our-mission.subsection-1.paragraph": {
     "message": "我们坚信，竞争不仅是健康的，而且对于提高我们运动的效率至关重要。竞争会给组织和项目带来健康的压力，促使其不断改进和迭代--这也会给我们提供更多信息，让我们知道什么是有效的。"
   },
-  "page.about.section.our-mission.subsection-2.heading": {
+  "page.about.section.our-mission.subsection-1.heading": {
     "message": "2.我们也需要更多的竞争。"
   },
-  "page.about.section.our-mission.subsection-3.content": {
+  "page.about.section.our-mission.subsection-2.paragraph": {
     "message": "我们相信，运动有潜力在方法上更具创新性。我们提倡打破常规思维，并将创新作为我们工作和流程每个部分的核心考虑因素。"
   },
-  "page.about.section.our-mission.subsection-3.heading": {
+  "page.about.section.our-mission.subsection-2.heading": {
     "message": "3.我们需要更加创新。"
   },
-  "page.about.section.our-mission.subsection-4.content": {
+  "page.about.section.our-mission.subsection-3.paragraph": {
     "message": "我们旨在帮助组织和个人以更有意义的方式进行联系与合作。我们需要利用我们的知识和相互之间的网络来支持我们的共同目标，无论是共享研究或数据、资源，还是相互支持以克服组织面临的挑战。"
   },
-  "page.about.section.our-mission.subsection-4.heading": {
+  "page.about.section.our-mission.subsection-3.heading": {
     "message": "4.我们需要开始合作。"
   },
-  "page.about.section.our-mission.subsection-5.content": {
+  "page.about.section.our-mission.subsection-4.paragraph": {
     "message": "世界上只有极少数人是素食主义者，其中一小部分人是积极的。许多组织鼓励非素食者出于健康、环境或道德原因采用素食主义。我们相信，我们也可以通过创造工具来帮助、激励更多的素食者成为动物的代言人。"
   },
-  "page.about.section.our-mission.subsection-5.heading": {
+  "page.about.section.our-mission.subsection-4.heading": {
     "message": "5.最后，我们需要更多的素食主义者积极行动起来。"
   },
   "page.about.section.our-story.next-seo.title": {
     "message": "我们的故事"
   },
-  "page.about.section.our-story.section-header.content": {
+  "page.about.section.our-story.intro.paragraph": {
     "message": "2019 年，我们与几名热衷于行动主义的志愿者一起启动了第一个项目。从那时起，我们已经成长为一个由高技能的专业软件工程师、设计师、数据科学家和内容创作者组成的社区，为运动提供支持。我们一开始就希望催化人们行动起来，激励他们成为动物的拥护者--我们始终坚持这一创始原则。我们的数字技能为我们的行动提供了动力。"
   },
-  "page.about.section.our-story.section-header.heading": {
+  "page.about.section.our-story.intro.heading": {
     "message": "我们的故事"
   },
-  "page.about.section.our-story.section-header.image.alt-text": {
+  "page.about.section.our-story.image.alt-text": {
     "message": "我们的故事"
   },
-  "page.about.section.our-story.subsection-1.content": {
+  "page.about.section.our-story.paragraph.0": {
     "message": "我们是 Vegan Hacktivists。我们的技能组合--无论是编写代码、创建品牌形象，还是分析数据--就像我们来自哪里、生活在哪里一样多种多样。我们相互协作，建立以数据为导向、具有实验性和有效性的项目。我们的核心团队由总监和高级团队成员组成，他们在工程、建筑、设计、数据、运营和沟通方面拥有丰富的经验和专业知识。我们的志愿者基础包括由负责人管理的团队；每个团队都拥有一个项目的所有权，并积极建设和维护该项目。"
   },
-  "page.about.section.our-story.subsection-2.content": {
+  "page.about.section.our-story.paragraph.1": {
     "message": "我们的组织以社区为先。鉴于我们的工作需要耐心和承诺，我们通过创造一个支持性的环境来激发志愿者的活力，使他们能够参与其中，提高效率和影响力。作为一个分布式组织，我们希望通过有意义和有趣的互动，建立一种价值观一致、相互联系的社区意识。每个团队都以一种<link>水果或蔬菜</link>为代表（将以植物为基础提升到另一个层次），我们通过游戏、聚会和社区电话来平衡我们的工作。毕竟，志愿者是我们组织的核心。"
   },
-  "page.about.section.our-story.subsection-3.content": {
+  "page.about.section.our-story.paragraph.2": {
     "message": "多年来，我们的组织随着运动的需要而变化。虽然我们现在主要专注于提供能力建设服务，但我们仍在继续开发我们认为具有创新性且在运动中非常需要的技术。现在，我们与倡导者、组织和前线工作者广泛合作，帮助他们改善日常运营、品牌和形象以及技术。通过这样做，我们帮助扩大他们的信息，将他们的工作推向更广泛的受众。"
   },
-  "page.about.section.our-story.subsection-4.content": {
+  "page.about.section.our-story.paragraph.3": {
     "message": "无论如何，我们的北极星始终如一：<no-localization>{break}</no-localization> ，我们是为了动物。"
   },
   "page.about.section.our-values.next-seo.title": {
@@ -167,40 +167,40 @@
   "page.about.section.our-values.section-header.image.alt-text": {
     "message": "我们的价值观"
   },
-  "page.about.section.our-values.subsection-1.content": {
+  "page.about.section.our-values.subsection-0.paragraph": {
     "message": "我们珍视并尊重所有动物的生命，谴责一切形式针对动物的暴力和剥削行为。我们相信动物有获得自由的权利，并通过我们的（数字）行动主义为之奋斗。"
   },
-  "page.about.section.our-values.subsection-1.heading": {
+  "page.about.section.our-values.subsection-0.heading": {
     "message": "动物解放"
   },
-  "page.about.section.our-values.subsection-2.content": {
+  "page.about.section.our-values.subsection-1.paragraph": {
     "message": "我们践行以爱为本，社区优先的组织方式。我们践行同理心、同情心和非暴力。我们鼓励每一位成员彼此坦诚、友好地交流。"
   },
-  "page.about.section.our-values.subsection-2.heading": {
+  "page.about.section.our-values.subsection-1.heading": {
     "message": "非暴力"
   },
-  "page.about.section.our-values.subsection-3.content": {
+  "page.about.section.our-values.subsection-2.paragraph": {
     "message": "我们相信，无论种族、性别、物种、年龄、性取向或政治派别如何，我们都能建立和培育安全、包容的社区。我们努力使我们所服务和工作的社区具有多样性和代表性。"
   },
-  "page.about.section.our-values.subsection-3.heading": {
+  "page.about.section.our-values.subsection-2.heading": {
     "message": "安全社区"
   },
-  "page.about.section.our-values.subsection-4.content": {
+  "page.about.section.our-values.subsection-3.paragraph": {
     "message": "我们认为养殖动物最需要我们的支持，这也是我们作为一个组织主要关注养殖动物解放的原因。"
   },
-  "page.about.section.our-values.subsection-4.heading": {
+  "page.about.section.our-values.subsection-3.heading": {
     "message": "养殖动物"
   },
-  "page.about.section.our-values.subsection-5.content": {
+  "page.about.section.our-values.subsection-4.paragraph": {
     "message": "我们重视来自每个人的不同观点和建设性反馈。我们相信每个人都能为讨论做出有价值的贡献。我们总是首先倾听，然后做出建设性的回应。"
   },
-  "page.about.section.our-values.subsection-5.heading": {
+  "page.about.section.our-values.subsection-4.heading": {
     "message": "公开反馈"
   },
-  "page.about.section.our-values.subsection-6.content": {
+  "page.about.section.our-values.subsection-5.paragraph": {
     "message": "我们不支持或助长对任何群体的剥削或压迫。我们认为，对人类和非人类动物的压迫是相互关联的，必须努力消除一切形式的压迫。"
   },
-  "page.about.section.our-values.subsection-6.heading": {
+  "page.about.section.our-values.subsection-5.heading": {
     "message": "反压迫"
   },
   "page.blog.next-seo.title": {


### PR DESCRIPTION
Making fixes including:

- Adding <no-localization> tags for text that shouldn't be translated
- Deleting translation setup where the header is split into parts
- Making IDs more uniform across all pages
- Ensuring all text is inside the default message and not in the object values
- Adding translation setup to text even if it isn't going to be translated anyway