### PR TITLE
Fix Donorbox height

### DIFF
--- a/src/components/layout/support/donorBoxCard.tsx
+++ b/src/components/layout/support/donorBoxCard.tsx
@@ -10,7 +10,6 @@ import type { StaticImageData } from 'next/image';
 interface DonorCardProps extends React.PropsWithChildren {
   color: string;
   image?: StaticImageData;
-  large?: boolean;
 }
 
 interface DonorBoxIframeProps
@@ -21,17 +20,12 @@ const DonorBoxIframe: React.FC<DonorBoxIframeProps> = ({ ...props }) => {
   return <iframe {...props} />;
 };
 
-const DonorBoxCard: React.FC<DonorCardProps> = ({ image, color, large }) => {
+const DonorBoxCard: React.FC<DonorCardProps> = ({ image, color }) => {
   const backgroundColor = getThemeColor(color);
   const scriptProps = { paypalExpress: 'false' };
 
   return (
-    <div
-      style={{
-        width: `${large ? '400px' : '300px'}`,
-      }}
-      className='flex flex-col bg-white'
-    >
+    <div className='flex flex-col bg-white w-[400px] h-[625px]'>
       {image && (
         <div style={{ backgroundColor }}>
           <div className={'absolute w-8 h-8 transparent'} />


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/fa49a6a7-1d88-41c5-b97e-c67642321595)

After (not sure if that's how it was initially supposed to look, but the flexbox explicitly aligns them this way):

![image](https://github.com/user-attachments/assets/e50214c1-a942-4106-b5c4-8fca7447aba5)
